### PR TITLE
Simplest swap

### DIFF
--- a/contracts/SimpleSwap.sol
+++ b/contracts/SimpleSwap.sol
@@ -93,7 +93,6 @@ contract SimpleSwap {
     }
   }
 
-
   function cashCheque(
     address beneficiary,
     address payable recipient,

--- a/contracts/SimpleSwap.sol
+++ b/contracts/SimpleSwap.sol
@@ -56,7 +56,7 @@ contract SimpleSwap {
   }
 
   /// @return the part of the balance usable for a specific beneficiary
-  function balanceFor(address beneficiary) public view returns(uint) {
+  function availableBalanceFor(address beneficiary) public view returns(uint) {
     return liquidBalance().add(hardDeposits[beneficiary].amount);
   }
 
@@ -76,7 +76,7 @@ contract SimpleSwap {
     uint requestPayout = cumulativePayout.sub(paidOut[beneficiary]);
 
     /* calculates acutal payout */
-    uint totalPayout = Math.min(requestPayout, balanceFor(beneficiary));
+    uint totalPayout = Math.min(requestPayout, availableBalanceFor(beneficiary));
     /* calculates hard-deposit usage */
     uint hardDepositUsage = Math.min(totalPayout, hardDeposits[beneficiary].amount);
     require(totalPayout >= calleePayout, "SimpleSwap: cannot pay callee");

--- a/contracts/SimpleSwap.sol
+++ b/contracts/SimpleSwap.sol
@@ -60,9 +60,15 @@ contract SimpleSwap {
     return liquidBalance().add(hardDeposits[beneficiary].amount);
   }
 
-  function _cashChequeInternal(address beneficiary, address payable recipient, uint cumulativePayout, uint calleePayout, bytes memory issuerSig) internal {
+  function _cashChequeInternal(
+    address beneficiary,
+    address payable recipient,
+    uint cumulativePayout,
+    uint calleePayout,
+    bytes memory issuerSig
+  ) internal {
     /* The issuer must have given explicit approval to the cumulativePayout, either by being the callee or by signature*/
-    if(msg.sender != issuer) {
+    if (msg.sender != issuer) {
       require(issuer == recover(chequeHash(address(this), beneficiary, cumulativePayout), issuerSig),
       "SimpleSwap: invalid issuerSig");
     }
@@ -74,9 +80,8 @@ contract SimpleSwap {
     /* calculates hard-deposit usage */
     uint hardDepositUsage = Math.min(totalPayout, hardDeposits[beneficiary].amount);
     require(totalPayout >= calleePayout, "SimpleSwap: cannot pay callee");
-    
     /* if there are some of the hard deposit used, update hardDeposits*/
-    if(hardDepositUsage != 0) {
+    if (hardDepositUsage != 0) {
       hardDeposits[beneficiary].amount = hardDeposits[beneficiary].amount.sub(hardDepositUsage);
 
       totalHardDeposit = totalHardDeposit.sub(hardDepositUsage);
@@ -87,13 +92,12 @@ contract SimpleSwap {
 
     recipient.transfer(totalPayout.sub(calleePayout));
     /* do a transfer to the callee if specified*/
-    if(calleePayout != 0) {
+    if (calleePayout != 0) {
       msg.sender.transfer(calleePayout);
     }
     emit ChequeCashed(beneficiary, recipient, msg.sender, totalPayout, cumulativePayout, calleePayout);
     /* let the world know that the issuer has over-promised on outstanding cheques */
-    if(requestPayout != totalPayout) {
-
+    if (requestPayout != totalPayout) {
       emit ChequeBounced();
     }
   }

--- a/contracts/SimpleSwap.sol
+++ b/contracts/SimpleSwap.sol
@@ -13,7 +13,7 @@ contract SimpleSwap {
     address indexed recipient,
     address indexed callee,
     uint totalPayout,
-    uint requestPayout,
+    uint cumulativePayout,
     uint calleePayout
   );
   event ChequeBounced();
@@ -67,7 +67,7 @@ contract SimpleSwap {
       "SimpleSwap: invalid issuerSig");
     }
     /* the requestPayout is the amount requested for payment processing */
-    uint requestPayout = paidOutCheques[beneficiary].sub(cumulativePayout);
+    uint requestPayout = cumulativePayout.sub(paidOutCheques[beneficiary]);
     /* calculates acutal payout */
     uint totalPayout = Math.min(requestPayout, balanceFor(beneficiary));
     /* calculates hard-deposit usage */
@@ -86,7 +86,7 @@ contract SimpleSwap {
     if(calleePayout != 0) {
       msg.sender.transfer(calleePayout);
     }
-    emit ChequeCashed(beneficiary, recipient, msg.sender, totalPayout, requestPayout, calleePayout);
+    emit ChequeCashed(beneficiary, recipient, msg.sender, totalPayout, cumulativePayout, calleePayout);
     /* let the world know that the issuer has over-promised on outstanding cheques */
     if(requestPayout != totalPayout) {
       emit ChequeBounced();

--- a/contracts/SimpleSwap.sol
+++ b/contracts/SimpleSwap.sol
@@ -87,8 +87,15 @@ contract SimpleSwap {
   ) internal {
     /* The issuer must have given explicit approval to the cumulativePayout, either by being the callee or by signature*/
     if (msg.sender != issuer) {
-      require(issuer == recover(chequeHash(address(this), beneficiary, cumulativePayout), issuerSig),
-      "SimpleSwap: invalid issuerSig");
+      require(
+        issuer == recover(
+          chequeHash(
+            address(this),
+            beneficiary,
+            cumulativePayout
+          ), issuerSig
+        ), "SimpleSwap: invalid issuerSig"
+      );
     }
     /* the requestPayout is the amount requested for payment processing */
     uint requestPayout = cumulativePayout.sub(paidOut[beneficiary]);
@@ -137,13 +144,16 @@ contract SimpleSwap {
     uint256 calleePayout,
     bytes memory issuerSig
   ) public {
-    require(beneficiary == recover(cashOutHash(
-      address(this),
-      msg.sender,
-      cumulativePayout,
-      recipient,
-      calleePayout
-      ), beneficiarySig), "SimpleSwap: invalid beneficiarySig");
+    require(
+      beneficiary == recover(
+        cashOutHash(
+          address(this),
+          msg.sender,
+          cumulativePayout,
+          recipient,
+          calleePayout
+        ), beneficiarySig
+      ), "SimpleSwap: invalid beneficiarySig");
     _cashChequeInternal(beneficiary, recipient, cumulativePayout, calleePayout, issuerSig);
   }
 

--- a/test/SimpleSwap.behavior.js
+++ b/test/SimpleSwap.behavior.js
@@ -15,18 +15,13 @@ const { sign } = require("./swutils");
 const { computeCost } = require("./testutils");
 const {
   shouldReturnDEFAULT_HARDDEPOSIT_DECREASE_TIMEOUT,
-  shouldReturnCheques,
+  shouldReturnPaidOutCheques,
   shouldReturnHardDeposits,
   shouldReturnTotalHardDeposit,
   shouldReturnIssuer,
   shouldReturnLiquidBalance,
-  shouldReturnLiquidBalanceFor,
-  shouldSubmitChequeIssuer,
-  shouldNotSubmitChequeIssuer,
+  shouldReturnBalanceFor,
   shouldSubmitChequeBeneficiary,
-  shouldNotSubmitChequeBeneficiary,
-  shouldSubmitCheque,
-  shouldNotSubmitCheque,
   shouldCashChequeBeneficiary,
   shouldNotCashChequeBeneficiary,
   shouldCashCheque,
@@ -49,22 +44,19 @@ const {
 enabledTests = {
   DEFAULT_HARDDEPOSIT_DECREASE_TIMEOUT: true,
   cheques: true,
-  hardDeposits: true,
-  totalHardDeposit: true,
-  issuer: true,
-  liquidBalance: true,
-  liquidBalanceFor: true,
-  submitChequeIssuer: true,
-  submitChequeBeneficiary: true,
-  submitCheque: true,
-  cashChequeBeneficiary: true,
-  cashCheque: true,
-  prepareDecreaseHardDeposit: true,
-  decreaseHardDeposit: true,
-  increaseHardDeposit: true,
-  setCustomHardDepositDecreaseTimeout: true,
-  withdraw: true, 
-  deposit: true
+  hardDeposits: false,
+  totalHardDeposit: false,
+  issuer: false,
+  liquidBalance: false,
+  liquidBalanceFor: false,
+  cashChequeBeneficiary: false,
+  cashCheque: false,
+  prepareDecreaseHardDeposit: false,
+  decreaseHardDeposit: false,
+  increaseHardDeposit: false,
+  setCustomHardDepositDecreaseTimeout: false,
+  withdraw: false, 
+  deposit: false
 }
 
 // constants to make the test-log more readable
@@ -80,11 +72,7 @@ const describeTest = 'TEST: '
 function shouldBehaveLikeSimpleSwap([issuer, alice, bob, _recipient], DEFAULT_HARDDEPOSIT_DECREASE_TIMEOUT) {
   const defaultCheque = {
     beneficiary: bob,
-    serial: new BN(3),
     amount: new BN(500),
-    timeout: new BN(86400),
-    signee: issuer,
-    signature: ""
   }
   context('as a simple swap', function () {
     describe(describeFunction + 'DEFAULT_HARDDEPOSIT_DECREASE_TIMEOUT', function () {
@@ -92,48 +80,24 @@ function shouldBehaveLikeSimpleSwap([issuer, alice, bob, _recipient], DEFAULT_HA
         shouldReturnDEFAULT_HARDDEPOSIT_DECREASE_TIMEOUT(DEFAULT_HARDDEPOSIT_DECREASE_TIMEOUT)
       }
     })
-
-    describe(describeFunction + 'cheques', function () {
+    describe(describeFunction + 'paidOutCheques', function () {
       if (enabledTests.cheques) {
         const beneficiary = defaultCheque.beneficiary
-        context('when no cheque was ever submitted', function () {
-          describe(describeTest + 'shouldReturnCheques', function () {
-            const expectedSerial = new BN(0)
+        context('when no cheque was ever cashed', function () {
+          describe(describeTest + 'shouldReturnPaidOutCheques', function () {
             const expectedAmount = new BN(0)
-            const expectedPaidOut = new BN(0)
-            const expectedCashTimeout = new BN(0)
-            shouldReturnCheques(beneficiary, expectedSerial, expectedAmount, expectedPaidOut, expectedCashTimeout)
+            shouldReturnPaidOutCheques(beneficiary, expectedAmount)
           })
         })
-        context('when a cheque was submitted but not cashed', function () {
-          const toSubmitCheque = defaultCheque
-          describe(describePreCondition + 'shouldSubmitChequeBeneficiary', function () {
-            shouldSubmitChequeBeneficiary(toSubmitCheque, defaultCheque.beneficiary)
-            describe(describeTest + 'shouldReturnCheques', function () {
-              const expectedSerial = toSubmitCheque.serial
-              const expectedAmount = toSubmitCheque.amount
-              const expectedPaidOut = new BN(0)
-              const expectedCashTimeout = toSubmitCheque.timeout
-              shouldReturnCheques(beneficiary, expectedSerial, expectedAmount, expectedPaidOut, expectedCashTimeout)
-            })
-            context('when a cheque was cashed', function () {
-              describe(describePreCondition + 'shouldDeposit', function() {
-                shouldDeposit(defaultCheque.amount, issuer)
-                describe(describePreCondition + 'shouldCashChequeBeneficiary', function () {
-                  beforeEach(async function() {
-                    await time.increase(toSubmitCheque.timeout)
-                  })
-                  shouldCashChequeBeneficiary(defaultCheque.beneficiary, defaultCheque.amount, defaultCheque.beneficiary)
-                  describe(describeTest + 'shouldReturnCheques', function () {
-                    const expectedSerial = toSubmitCheque.serial
-                    const expectedAmount = toSubmitCheque.amount
-                    const expectedPaidOut = toSubmitCheque.amount
-                    const expectedCashTimeout = toSubmitCheque.timeout
-                    shouldReturnCheques(beneficiary, expectedSerial, expectedAmount, expectedPaidOut, expectedCashTimeout)
-                  })
-                })
+        context('when a cheque was cashed', function () {
+          describe(describePreCondition + 'shouldDeposit', function() {
+            shouldDeposit(defaultCheque.amount, issuer)
+            describe(describePreCondition + 'shouldCashChequeBeneficiary', function () {
+              shouldCashChequeBeneficiary(defaultCheque.beneficiary, defaultCheque.amount, issuer, defaultCheque.beneficiary)
+              describe(describeTest + 'shouldReturnPaidOutCheques', function () {
+                const expectedAmount = defaultCheque.amount
+                shouldReturnPaidOutCheques(beneficiary, expectedAmount)
               })
-              
             })
           })
         })
@@ -263,7 +227,7 @@ function shouldBehaveLikeSimpleSwap([issuer, alice, bob, _recipient], DEFAULT_HA
       }
     })
 
-    describe(describeFunction + 'liquidBalanceFor', function () {
+    describe(describeFunction + 'shouldReturnBalanceFor', function () {
       if (enabledTests.liquidBalanceFor) {
         const beneficiary = bob
         const depositAmount = new BN(50)
@@ -271,8 +235,8 @@ function shouldBehaveLikeSimpleSwap([issuer, alice, bob, _recipient], DEFAULT_HA
           describe(describePreCondition + 'shoulDeposit', function () {
             shouldDeposit(depositAmount, issuer)
             context('when there are no hard deposits', function () {
-              describe(describeTest + 'shouldReturnLiquidBalanceFor', function () {
-                shouldReturnLiquidBalanceFor(beneficiary, depositAmount)
+              describe(describeTest + 'shouldReturnBalanceFor', function () {
+                shouldReturnBalanceFor(beneficiary, depositAmount)
               })
             })
             context('when there are no hard deposits', function () {
@@ -280,16 +244,16 @@ function shouldBehaveLikeSimpleSwap([issuer, alice, bob, _recipient], DEFAULT_HA
               describe('when these hard deposits are assigned to the beneficiary', function () {
                 describe(describePreCondition + 'shouldIncreaseHardDeposit', function () {
                   shouldIncreaseHardDeposit(beneficiary, hardDeposit, issuer)
-                  describe(describeTest + 'shouldReturnLiquidBalanceFor', function () {
-                    shouldReturnLiquidBalanceFor(beneficiary, depositAmount)
+                  describe(describeTest + 'shouldReturnBalanceFor', function () {
+                    shouldReturnBalanceFor(beneficiary, depositAmount)
                   })
                 })
               })
               describe('when these hard deposits are assigned to somebody else', function () {
                 describe(describePreCondition + 'shouldIncreaseHardDeposit', function () {
                   shouldIncreaseHardDeposit(alice, hardDeposit, issuer)
-                  describe(describeTest + 'shouldReturnLiquidBalanceFor', function () {
-                    shouldReturnLiquidBalanceFor(beneficiary, depositAmount.sub(hardDeposit))
+                  describe(describeTest + 'shouldReturnBalanceFor', function () {
+                    shouldReturnBalanceFor(beneficiary, depositAmount.sub(hardDeposit))
                   })
                 })
               })
@@ -297,373 +261,7 @@ function shouldBehaveLikeSimpleSwap([issuer, alice, bob, _recipient], DEFAULT_HA
           })
         })
         describe('when there is no balance', function () {
-          shouldReturnLiquidBalanceFor(beneficiary, new BN(0))
-        })
-      }
-    })
-
-    describe(describeFunction + 'submitChequeIssuer', function () {
-      if (enabledTests.submitChequeIssuer) {
-        context("when we don't send value along", function () {
-          const value = new BN(0)
-          context('when the sender is the issuer', function () {
-            const sender = issuer
-            context('when the first serial is higher than 0', function () {
-              expect(defaultCheque.serial).bignumber.to.be.above(new BN(0), "Serial of defaultCheque not above 0")
-              context('when the first serial is below MAX_UINT256', function () {
-                expect(defaultCheque.serial).bignumber.to.be.below(constants.MAX_UINT256, "Serial of defaultCheque not above 0")
-                context('when the beneficiary is a signee', function () {
-                  const unsignedCheque = Object.assign({}, defaultCheque, { signee: defaultCheque.beneficiary })
-                  expect(unsignedCheque.signee).to.be.equal(unsignedCheque.beneficiary, "Signee of unsignedCheque is not beneficiary")
-                  context('when the signee signs the correct fields', function () {
-                    context('when we send one cheque', function () {
-                      context('when there is a liquidBalance to cover the cheque', function () {
-                        describe(describePreCondition + 'shouldDeposit', function () {
-                          describe(describePreCondition + 'shouldDeposit', function () {
-                            shouldDeposit(unsignedCheque.amount.add(unsignedCheque.amount), issuer)
-                            describe(describeTest + 'submitChequeIssuer', function () {
-                              shouldSubmitChequeIssuer(unsignedCheque, sender)
-                            })
-                          })
-                        })
-                      })
-                      context('when there is no liquidBalance to cover the cheque', function () {
-                        describe(describeTest + 'shouldSubmitChequeIssuer', function () {
-                          shouldSubmitChequeIssuer(unsignedCheque, sender)
-                        })
-                      })
-                    })
-                    context('when we send more than one cheque', async function () {
-                      describe(describePreCondition + 'shouldSubmitChequeIssuer', function () {
-                        shouldSubmitChequeIssuer(unsignedCheque, sender)
-                        context('when the serial number is increasing', function () {
-                          describe(describeTest + 'shouldSubmitChequeIssuer', function () {
-                            const secondSerial = unsignedCheque.serial.add(new BN(1))
-                            const increasing_serial_unsignedCheque = Object.assign({}, defaultCheque, { serial: secondSerial, signee: defaultCheque.beneficiary })
-                            shouldSubmitChequeIssuer(increasing_serial_unsignedCheque, sender)
-                          })
-                        })
-                        context('when the serial number stays the same', function () {
-                          context('when the serial number is increasing', function () {
-                            describe(describeTest + 'shouldSubmitChequeIssuer', function () {
-                              const secondSerial = unsignedCheque.serial
-                              const same_serial_unsignedCheque = Object.assign({}, defaultCheque, { serial: secondSerial, signee: defaultCheque.beneficiary })
-                              shouldNotSubmitChequeIssuer(same_serial_unsignedCheque, same_serial_unsignedCheque, sender, value, "SimpleSwap: invalid serial")
-                            })
-                          })
-                          context('when the serial number is decreasing', function () {
-                            context('when the serial number is increasing', function () {
-                              describe(describeTest + 'shouldSubmitChequeIssuer', function () {
-                                const secondSerial = unsignedCheque.serial.sub(new BN(1))
-                                const decreasing_serial_unsignedCheque = Object.assign({}, defaultCheque, { serial: secondSerial, signee: defaultCheque.beneficiary })
-                                shouldNotSubmitChequeIssuer(decreasing_serial_unsignedCheque, decreasing_serial_unsignedCheque, sender, value, "SimpleSwap: invalid serial")
-                              })
-                            })
-                          })
-                        })
-                      })
-                    })
-                  })
-                  context('when the signee does not sign the correct fields', function () {
-                    describe(describeTest + 'shouldSubmitChequeIssuer', function () {
-                      const wrongBeneficiary = constants.ZERO_ADDRESS
-                      const wrong_beneficiary_unsignedCheque = Object.assign({}, defaultCheque, { beneficiary: wrongBeneficiary, signee: defaultCheque.beneficiary })
-                      shouldNotSubmitChequeIssuer(wrong_beneficiary_unsignedCheque, defaultCheque, sender, value, "SimpleSwap: invalid beneficiarySig")
-                    })
-                  })
-                })
-                context('when the beneficiary is not the signee', function () {
-                  describe(describeTest + 'shouldSubmitChequeIssuer', function () {
-                    const signee = alice
-                    const wrong_signee_unsignedCheque = Object.assign({}, defaultCheque, { signee: signee })
-                    shouldNotSubmitChequeIssuer(wrong_signee_unsignedCheque, defaultCheque, sender, value, "SimpleSwap: invalid beneficiarySig")
-                  })
-                })
-              })
-              context('when the first serial is at MAX_UINT256', function () {
-                describe(describeTest + 'shouldSubmitChequeIssuer', function () {
-                  const MAX_UINT256_unsignedCheque = Object.assign({}, defaultCheque, { serial: constants.MAX_UINT256, signee: defaultCheque.beneficiary })
-                  shouldSubmitChequeIssuer(MAX_UINT256_unsignedCheque, issuer)
-                  describe('when we want to submit a cheque afterwards', function () {
-                    describe(describeTest + 'shouldNotSubmitChequeIssuer', function () {
-                      const MAX_UINT256_wrap_unsignedCheque = Object.assign({}, defaultCheque, { serial: MAX_UINT256_unsignedCheque.serial.add(new BN(1)), signee: defaultCheque.beneficiary })
-                      shouldNotSubmitChequeIssuer(MAX_UINT256_wrap_unsignedCheque, MAX_UINT256_wrap_unsignedCheque, sender, value, "SimpleSwap: invalid serial")
-                    })
-                  })
-                })
-              })
-            })
-            context('when the serial is 0', function () {
-              describe(describeTest + 'shouldNotSubmitChequeIssuer', function () {
-                const serial = new BN(0)
-                const zero_serial_unsignedCheque = Object.assign({}, defaultCheque, { serial: serial, signee: defaultCheque.beneficiary })
-                shouldNotSubmitChequeIssuer(zero_serial_unsignedCheque, zero_serial_unsignedCheque, sender, value, "SimpleSwap: invalid serial")
-              })
-            })
-          })
-          context('when the sender is not the issuer', function () {
-            describe(describeTest + 'shouldNotSubmitChequeIssuer', function () {
-              const sender = alice
-              const unsignedCheque = Object.assign({}, defaultCheque, { signee: defaultCheque.beneficiary })
-              shouldNotSubmitChequeIssuer(unsignedCheque, unsignedCheque, sender, value, "SimpleSwap: not issuer")
-            })
-          })
-        })
-        context("when we send value along", function () {
-          describe(describeTest + 'shouldNotSubmitChequeIssuer', function () {
-            const value = new BN(0)
-            const sender = issuer
-            const unsignedCheque = Object.assign({}, defaultCheque, { signee: defaultCheque.beneficiary })
-            shouldNotSubmitChequeBeneficiary(unsignedCheque, unsignedCheque, sender, value, "revert")
-          })
-        })
-      }
-    })
-
-    describe(describeFunction + 'submitChequeBeneficiary', function () {
-      if (enabledTests.submitChequeBeneficiary) {
-        context("when we don't send value along", function () {
-          const value = new BN(0)
-          context('when the sender is the beneficiary', function () {
-            const sender = defaultCheque.beneficiary
-            context('when the first serial is higher than 0', function () {
-              expect(defaultCheque.serial).bignumber.to.be.above(new BN(0), "Serial of defaultCheque not above 0")
-              context('when the first serial is below MAX_UINT256', function () {
-                expect(defaultCheque.serial).bignumber.to.be.below(constants.MAX_UINT256, "Serial of defaultCheque not above 0")
-                context('when the issuer is a signee', function () {
-                  expect(defaultCheque.signee).to.be.equal(issuer, "Signee of defaultCheque is not issuer")
-                  context('when the signee signs the correct fields', function () {
-                    const unsignedCheque = Object.assign({}, defaultCheque)
-                    context('when we send one cheque', function () {
-                      context('when there is a liquidBalance to cover the cheque', function () {
-                        describe(describePreCondition + 'shouldDeposit', function () {
-                          shouldDeposit(unsignedCheque.amount.add(new BN(1)), issuer)
-                          describe(describeTest + 'shouldSubmitChequeBeneficiary', function () {
-                            shouldSubmitChequeBeneficiary(unsignedCheque, sender)
-                          })
-                        })
-                      })
-                      context('when there is no liquidBalance to cover the cheque', function () {
-                        describe(describeTest + 'shouldSubmitChequeBeneficiary', function () {
-                          shouldSubmitChequeBeneficiary(unsignedCheque, sender)
-                        })
-                      })
-                    })
-                    context('when we send more than one cheque', async function () {
-                      describe(describePreCondition + 'shouldSubmitChequeBeneficiary', function () {
-                        shouldSubmitChequeBeneficiary(unsignedCheque, sender)
-                        context('when the serial number is increasing', function () {
-                          describe(describeTest + 'shouldSubmitChequeBeneficiary', function () {
-                            const secondSerial = unsignedCheque.serial.add(new BN(1))
-                            const increasing_serial_unsignedCheque = Object.assign({}, defaultCheque, { serial: secondSerial })
-                            shouldSubmitChequeBeneficiary(increasing_serial_unsignedCheque, sender)
-                          })
-                        })
-                        context('when the serial number stays the same', function () {
-                          describe(describeTest + 'shouldSubmitChequeBeneficiary', function () {
-                            const secondSerial = unsignedCheque.serial
-                            const same_serial_unsignedCheque = Object.assign({}, defaultCheque, { serial: secondSerial })
-                            shouldNotSubmitChequeBeneficiary(same_serial_unsignedCheque, same_serial_unsignedCheque, sender, value, "SimpleSwap: invalid serial")
-                          })
-                          context('when the serial number is decreasing', function () {
-                            describe(describeTest + 'shouldSubmitChequeBeneficiary', function () {
-                              const secondSerial = unsignedCheque.serial.sub(new BN(1))
-                              const decreasing_serial_unsignedCheque = Object.assign({}, defaultCheque, { serial: secondSerial })
-                              shouldNotSubmitChequeBeneficiary(decreasing_serial_unsignedCheque, decreasing_serial_unsignedCheque, sender, value, "SimpleSwap: invalid serial")
-                            })
-                          })
-                        })
-                      })
-                    })
-                    context('when the signee does not sign the correct fields', function () {
-                      describe(describeTest + 'shouldNotSubmitChequeBeneficiary', function () {
-                        const wrongBeneficiary = constants.ZERO_ADDRESS
-                        const wrong_beneficiary_unsignedCheque = Object.assign({}, defaultCheque, { beneficiary: wrongBeneficiary })
-                        shouldNotSubmitChequeBeneficiary(wrong_beneficiary_unsignedCheque, defaultCheque, sender, value, "SimpleSwap: invalid issuerSig")
-                      })
-                    })
-                  })
-                  context('when the issuer is not the signee', function () {
-                    describe(describeTest + 'shouldNotSubmitChequeBeneficiary', function () {
-                      const signee = alice
-                      const wrong_signee_unsignedCheque = Object.assign({}, defaultCheque, { signee: signee })
-                      shouldNotSubmitChequeBeneficiary(wrong_signee_unsignedCheque, wrong_signee_unsignedCheque, sender, value, "SimpleSwap: invalid issuerSig")
-                    })
-                  })
-                })
-                context('when the first serial is at MAX_UINT256', function () {
-                  describe(describeTest + 'shouldSubmitChequeBeneficiary', function () {
-                    const MAX_UINT256_unsignedCheque = Object.assign({}, defaultCheque, { serial: constants.MAX_UINT256 })
-                    shouldSubmitChequeBeneficiary(MAX_UINT256_unsignedCheque, defaultCheque.beneficiary)
-                    context('when we want to submit a cheque afterwards', function () {
-                      describe(describeTest + 'shouldNotSubmitChequeBeneficiary', function () {
-                        // Solidity wraps integers
-                        const MAX_UINT256_wrap_unsignedCheque = Object.assign({}, defaultCheque, { serial: MAX_UINT256_unsignedCheque.serial.add(new BN(1)) })
-                        shouldNotSubmitChequeBeneficiary(MAX_UINT256_wrap_unsignedCheque, MAX_UINT256_wrap_unsignedCheque, sender, value, "SimpleSwap: invalid serial")
-                      })
-                    })
-                  })
-                })
-              })
-            })
-            context('when the serial is 0', function () {
-              describe(describeTest + 'shouldNotSubmitChequeBeneficiary', function () {
-                const serial = new BN(0)
-                const zero_serial_unsignedCheque = Object.assign({}, defaultCheque, { serial: serial })
-                shouldNotSubmitChequeBeneficiary(zero_serial_unsignedCheque, zero_serial_unsignedCheque, sender, value, "SimpleSwap: invalid serial")
-              })
-            })
-          })
-          context('when the sender is not the beneficiary', function () {
-            describe(describeTest + 'shouldNotSubmitChequeBeneficiary', function () {
-              const sender = alice
-              shouldNotSubmitChequeBeneficiary(defaultCheque, defaultCheque, sender, value, "SimpleSwap: invalid issuerSig")
-            })
-          })
-        })
-        context('when we send value along', function () {
-          const value = new BN(1)
-          const sender = defaultCheque.beneficiary
-          shouldNotSubmitChequeBeneficiary(defaultCheque, defaultCheque, sender, value, "revert")
-        })
-      }
-    })
-
-    describe(describeFunction + 'submitCheque', function () {
-      if (enabledTests.submitChequeBeneficiary) {
-        context("when we don't send value along", function () {
-          const value = new BN(0)
-          context('when the first serial is higher than 0', function () {
-            expect(defaultCheque.serial).bignumber.to.be.above(new BN(0), "Serial of defaultCheque not above 0")
-            context('when the first serial is below MAX_UINT256', function () {
-              expect(defaultCheque.serial).bignumber.to.be.below(constants.MAX_UINT256, "Serial of defaultCheque not above 0")
-              context('when the beneficiary and issuer are a signee', function () {
-                const signees = [issuer, defaultCheque.beneficiary]
-                context('when the signee signs the correct fields', function () {
-                  const unsignedCheque = Object.assign({}, defaultCheque, { signee: signees })
-                  context('when we send one cheque', function () {
-                    context('when there is a liquidBalance to cover the cheque', function () {
-                      describe(describePreCondition + 'shouldDeposit', function () {
-                        shouldDeposit(unsignedCheque.amount, issuer)
-                        describe('when the sender is neither the beneficiary nor the issuer', function () {
-                          describe(describeTest + 'shouldSubmitChequeBeneficiary', function () {
-                            const sender = alice
-                            shouldSubmitCheque(unsignedCheque, sender)
-                          })
-                        })
-                        describe('when the sender is the beneficiary', function () {
-                          describe(describeTest + 'shouldSubmitChequeBeneficiary', function () {
-                            const sender = unsignedCheque.beneficiary
-                            shouldSubmitCheque(unsignedCheque, sender)
-                          })
-                        })
-                        describe('when the sender is the issuer', function () {
-                          describe(describeTest + 'shouldSubmitChequeBeneficiary', function () {
-                            const sender = issuer
-                            shouldSubmitCheque(unsignedCheque, sender)
-                          })
-                        })
-
-                      })
-                    })
-                    context('when there is no liquidBalance to cover the cheque', function () {
-                      describe(describeTest + 'shouldSubmitCheque', function () {
-                        const sender = alice
-                        shouldSubmitCheque(unsignedCheque, sender)
-                      })
-                    })
-                  })
-                  context('when we send more than one cheque', async function () {
-                    const sender = alice
-                    shouldSubmitCheque(unsignedCheque, sender)
-                    context('when the serial number is increasing', function () {
-                      describe(describeTest + 'shouldSubmitCheque', function () {
-                        const secondSerial = unsignedCheque.serial.add(new BN(1))
-                        const increasing_serial_unsignedCheque = Object.assign({}, defaultCheque, { serial: secondSerial, signee: signees })
-                        shouldSubmitCheque(increasing_serial_unsignedCheque, sender)
-                      })
-                    })
-                    context('when the serial number stays the same', function () {
-                      describe(describeTest + 'shouldNotSubmitCheque', function () {
-                        const secondSerial = unsignedCheque.serial
-                        const same_serial_unsignedCheque = Object.assign({}, defaultCheque, { serial: secondSerial, signee: signees })
-                        shouldNotSubmitCheque(same_serial_unsignedCheque, same_serial_unsignedCheque, sender, value, "SimpleSwap: invalid serial")
-                      })
-                    })
-                    context('when the serial number is decreasing', function () {
-                      describe(describeTest + 'shouldNotSubmitCheque', function () {
-                        const secondSerial = unsignedCheque.serial.sub(new BN(1))
-                        const decreasing_serial_unsignedCheque = Object.assign({}, defaultCheque, { serial: secondSerial, signee: signees })
-                        shouldNotSubmitCheque(decreasing_serial_unsignedCheque, decreasing_serial_unsignedCheque, sender, value, "SimpleSwap: invalid serial")
-                      })
-                    })
-                  })
-                })
-                context("when the signees don't not sign the correct fields", function () {
-                  describe(describeTest + 'shouldNotSubmitCheque', function () {
-                    const sender = alice
-                    const wrongBeneficiary = constants.ZERO_ADDRESS
-                    const wrong_beneficiary_unsignedCheque = Object.assign({}, defaultCheque, { beneficiary: wrongBeneficiary, signee: signees })
-                    const functionParams = defaultCheque
-                    shouldNotSubmitCheque(wrong_beneficiary_unsignedCheque, functionParams, sender, value, "SimpleSwap: invalid issuerSig")
-                  })
-                })
-              })
-              context('when the issuer is not the signee', function () {
-                describe(describeTest + 'shouldNotSubmitCheque', function () {
-                  const sender = alice
-                  const signees = [alice, defaultCheque.beneficiary]
-                  const wrong_signee_unsignedCheque = Object.assign({}, defaultCheque, { signee: signees })
-                  shouldNotSubmitCheque(wrong_signee_unsignedCheque, wrong_signee_unsignedCheque, sender, value, "SimpleSwap: invalid issuerSig")
-                })
-              })
-              context('when the beneficiary is not the signee', function () {
-                describe(describeTest + 'shouldNotSubmitCheque', function () {
-                  const sender = alice
-                  const signees = [issuer, alice]
-                  const wrong_signee_unsignedCheque = Object.assign({}, defaultCheque, { signee: signees })
-                  shouldNotSubmitCheque(wrong_signee_unsignedCheque, wrong_signee_unsignedCheque, sender, value, "SimpleSwap: invalid beneficiarySig")
-                })
-              })
-              context('when neither the issuer nor the beneficiary are a signee', function () {
-                describe(describeTest + 'shouldNotSubmitCheque', function () {
-                  const sender = alice
-                  const signees = [alice, alice]
-                  const wrong_signee_unsignedCheque = Object.assign({}, defaultCheque, { signee: signees })
-                  shouldNotSubmitCheque(wrong_signee_unsignedCheque, wrong_signee_unsignedCheque, sender, value, "SimpleSwap: invalid issuerSig")
-                })
-              })
-            })
-            context('when the first serial is at MAX_UINT256', function () {
-              const sender = alice
-              describe(describePreCondition + 'shouldSubmitCheque', function () {
-                const signees = [issuer, defaultCheque.beneficiary]
-                const MAX_UINT256_unsignedCheque = Object.assign({}, defaultCheque, { serial: constants.MAX_UINT256, signee: signees })
-                shouldSubmitCheque(MAX_UINT256_unsignedCheque, defaultCheque.beneficiary)
-                describe(describeTest + 'shouldNotSubmitCheque', function () {
-                  // Solidity wraps integers
-                  const MAX_UINT256_wrap_unsignedCheque = Object.assign({}, defaultCheque, { serial: MAX_UINT256_unsignedCheque.serial.add(new BN(1)), signee: signees })
-                  shouldNotSubmitCheque(MAX_UINT256_wrap_unsignedCheque, MAX_UINT256_wrap_unsignedCheque, sender, value, "SimpleSwap: invalid serial")
-                })
-              })
-            })
-          })
-          context('when the serial is 0', function () {
-            const sender = alice
-            const signees = [issuer, defaultCheque.beneficiary]
-            const serial = new BN(0)
-            const zero_serial_unsignedCheque = Object.assign({}, defaultCheque, { serial: serial, signee: signees })
-            shouldNotSubmitCheque(zero_serial_unsignedCheque, zero_serial_unsignedCheque, sender, value, "SimpleSwap: invalid serial")
-          })
-        })
-        context('when we send value along', function () {
-          const sender = alice
-          const value = new BN(1)
-          let signees = [issuer, defaultCheque.beneficiary]
-          const unsignedCheque = Object.assign({}, defaultCheque, { signee: signees })
-          describe(describeTest, 'shouldNotSubmitCheque', function () {
-            shouldNotSubmitCheque(unsignedCheque, defaultCheque, sender, value, "revert")
-          })
+          shouldReturnBalanceFor(beneficiary, new BN(0))
         })
       }
     })

--- a/test/SimpleSwap.behavior.js
+++ b/test/SimpleSwap.behavior.js
@@ -10,7 +10,7 @@ const {
   shouldReturnTotalHardDeposit,
   shouldReturnIssuer,
   shouldReturnLiquidBalance,
-  shouldReturnBalanceFor,
+  shouldReturnAvailableBalanceFor,
   shouldCashChequeBeneficiary,
   shouldNotCashChequeBeneficiary,
   shouldCashCheque,
@@ -37,7 +37,7 @@ enabledTests = {
   totalHardDeposit: true,
   issuer: true,
   liquidBalance: true,
-  balanceFor: true,
+  availableBalanceFor: true,
   cashChequeBeneficiary: true,
   cashCheque: true,
   prepareDecreaseHardDeposit: true,
@@ -222,16 +222,16 @@ function shouldBehaveLikeSimpleSwap([issuer, alice, bob, carol], DEFAULT_HARDDEP
       }
     })
 
-    describe(describeFunction + 'shouldReturnBalanceFor', function () {
-      if (enabledTests.balanceFor) {
+    describe(describeFunction + 'shouldReturnAvailableBalanceFor', function () {
+      if (enabledTests.availableBalanceFor) {
         const beneficiary = bob
         const depositAmount = new BN(50)
         context('when there is some balance', function () {
           describe(describePreCondition + 'shoulDeposit', function () {
             shouldDeposit(depositAmount, issuer)
             context('when there are no hard deposits', function () {
-              describe(describeTest + 'shouldReturnBalanceFor', function () {
-                shouldReturnBalanceFor(beneficiary, depositAmount)
+              describe(describeTest + 'shouldReturnAvailableBalanceFor', function () {
+                shouldReturnAvailableBalanceFor(beneficiary, depositAmount)
               })
             })
             context('when there are no hard deposits', function () {
@@ -239,16 +239,16 @@ function shouldBehaveLikeSimpleSwap([issuer, alice, bob, carol], DEFAULT_HARDDEP
               describe('when these hard deposits are assigned to the beneficiary', function () {
                 describe(describePreCondition + 'shouldIncreaseHardDeposit', function () {
                   shouldIncreaseHardDeposit(beneficiary, hardDeposit, issuer)
-                  describe(describeTest + 'shouldReturnBalanceFor', function () {
-                    shouldReturnBalanceFor(beneficiary, depositAmount)
+                  describe(describeTest + 'shouldReturnAvailableBalanceFor', function () {
+                    shouldReturnAvailableBalanceFor(beneficiary, depositAmount)
                   })
                 })
               })
               describe('when these hard deposits are assigned to somebody else', function () {
                 describe(describePreCondition + 'shouldIncreaseHardDeposit', function () {
                   shouldIncreaseHardDeposit(alice, hardDeposit, issuer)
-                  describe(describeTest + 'shouldReturnBalanceFor', function () {
-                    shouldReturnBalanceFor(beneficiary, depositAmount.sub(hardDeposit))
+                  describe(describeTest + 'shouldReturnAvailableBalanceFor', function () {
+                    shouldReturnAvailableBalanceFor(beneficiary, depositAmount.sub(hardDeposit))
                   })
                 })
               })
@@ -256,7 +256,7 @@ function shouldBehaveLikeSimpleSwap([issuer, alice, bob, carol], DEFAULT_HARDDEP
           })
         })
         describe('when there is no balance', function () {
-          shouldReturnBalanceFor(beneficiary, new BN(0))
+          shouldReturnAvailableBalanceFor(beneficiary, new BN(0))
         })
       }
     })

--- a/test/SimpleSwap.should.js
+++ b/test/SimpleSwap.should.js
@@ -108,7 +108,7 @@ function shouldReturnLiquidBalance(expectedLiquidBalance) {
 
 function shouldReturnBalanceFor(beneficiary, expectedBalanceFor) {
   it('should return the expected liquidBalance', async function() {
-    expect(await this.simpleSwap.balanceFor(beneficiary)).bignumber.to.equal(expectedLiquidBalance)
+    expect(await this.simpleSwap.balanceFor(beneficiary)).bignumber.to.equal(expectedBalanceFor)
   })
 }
 
@@ -233,11 +233,15 @@ function shouldCashChequeBeneficiary(recipient, cumulativePayout, signee, from) 
   })
   cashChequeInternal(from, recipient, cumulativePayout, new BN(0), from)
 }
-function shouldNotCashChequeBeneficiary(recipient, requestPayout, from, value, revertMessage) {
+function shouldNotCashChequeBeneficiary(recipient, toSubmitCumulativePayout, toSignCumulativePayout, signee, from, value, revertMessage) {
+  beforeEach(async function() {
+    this.issuerSig = await signCheque(this.simpleSwap, from, toSignCumulativePayout, signee)
+  })
   it('reverts', async function() {
     await expectRevert(this.simpleSwap.cashChequeBeneficiary(
       recipient,
-      requestPayout,
+      toSubmitCumulativePayout,
+      this.issuerSig,
      {from: from, value: value}), 
      revertMessage
     )

--- a/test/SimpleSwap.should.js
+++ b/test/SimpleSwap.should.js
@@ -106,9 +106,9 @@ function shouldReturnLiquidBalance(expectedLiquidBalance) {
   })
 }
 
-function shouldReturnBalanceFor(beneficiary, expectedBalanceFor) {
+function shouldReturnAvailableBalanceFor(beneficiary, expectedAvailableBalanceFor) {
   it('should return the expected liquidBalance', async function() {
-    expect(await this.simpleSwap.balanceFor(beneficiary)).bignumber.to.equal(expectedBalanceFor)
+    expect(await this.simpleSwap.availableBalanceFor(beneficiary)).bignumber.to.equal(expectedAvailableBalanceFor)
   })
 }
 
@@ -118,12 +118,12 @@ function cashChequeInternal(beneficiary, recipient, cumulativePayout, calleePayo
   beforeEach(async function() {
     let requestPayout = cumulativePayout.sub(this.preconditions.paidOut)
     //if the requested payout is less than the liquidBalance available for beneficiary
-    if(requestPayout.lt(this.preconditions.balanceFor)) {
+    if(requestPayout.lt(this.preconditions.availableBalanceFor)) {
       // full amount requested can be paid out
       this.totalPayout = requestPayout
     } else {
       // partial amount requested can be paid out (the liquid balance available to the node)
-      this.totalPayout = this.preconditions.balanceFor
+      this.totalPayout = this.preconditions.availableBalanceFor
     }
   })
   
@@ -206,7 +206,7 @@ function shouldCashChequeBeneficiary(recipient, cumulativePayout, signee, from) 
       totalHardDeposit: await this.simpleSwap.totalHardDeposit(),
       hardDepositFor: await this.simpleSwap.hardDeposits(from),
       liquidBalance: await this.simpleSwap.liquidBalance(),
-      balanceFor: await this.simpleSwap.balanceFor(from),
+      availableBalanceFor: await this.simpleSwap.availableBalanceFor(from),
       chequebookBalance: await balance.current(this.simpleSwap.address),
       beneficiaryBalance: await balance.current(recipient),
       paidOut: await this.simpleSwap.paidOut(from)
@@ -225,7 +225,7 @@ function shouldCashChequeBeneficiary(recipient, cumulativePayout, signee, from) 
       totalHardDeposit: await this.simpleSwap.totalHardDeposit(),
       hardDepositFor: await this.simpleSwap.hardDeposits(from),
       liquidBalance: await this.simpleSwap.liquidBalance(),
-      balanceFor: await this.simpleSwap.balanceFor(from),
+      availableBalanceFor: await this.simpleSwap.availableBalanceFor(from),
       chequebookBalance: await balance.current(this.simpleSwap.address),
       beneficiaryBalance: await balance.current(recipient),
       paidOut: await this.simpleSwap.paidOut(from)
@@ -258,7 +258,7 @@ function shouldCashCheque(beneficiary, recipient, cumulativePayout, calleePayout
       totalHardDeposit: await this.simpleSwap.totalHardDeposit(),
       hardDepositFor: await this.simpleSwap.hardDeposits(beneficiary),
       liquidBalance: await this.simpleSwap.liquidBalance(),
-      balanceFor: await this.simpleSwap.balanceFor(beneficiary),
+      availableBalanceFor: await this.simpleSwap.availableBalanceFor(beneficiary),
       chequebookBalance: await balance.current(this.simpleSwap.address),
       beneficiaryBalance: await balance.current(recipient),
       paidOut: await this.simpleSwap.paidOut(beneficiary)
@@ -274,7 +274,7 @@ function shouldCashCheque(beneficiary, recipient, cumulativePayout, calleePayout
       totalHardDeposit: await this.simpleSwap.totalHardDeposit(),
       hardDepositFor: await this.simpleSwap.hardDeposits(beneficiary),
       liquidBalance: await this.simpleSwap.liquidBalance(),
-      balanceFor: await this.simpleSwap.balanceFor(beneficiary),
+      availableBalanceFor: await this.simpleSwap.availableBalanceFor(beneficiary),
       chequebookBalance: await balance.current(this.simpleSwap.address),
       beneficiaryBalance: await balance.current(recipient),
       paidOut: await this.simpleSwap.paidOut(beneficiary)
@@ -399,7 +399,7 @@ function shouldIncreaseHardDeposit(beneficiary, amount, from) {
     this.preconditions = {
       balance: await balance.current(this.simpleSwap.address),
       liquidBalance: await this.simpleSwap.liquidBalance(),
-      balanceFor: await this.simpleSwap.balanceFor(beneficiary),
+      availableBalanceFor: await this.simpleSwap.availableBalanceFor(beneficiary),
       totalHardDeposit: await this.simpleSwap.totalHardDeposit(),
       hardDepositFor: await this.simpleSwap.hardDeposits(beneficiary),
     }
@@ -408,7 +408,7 @@ function shouldIncreaseHardDeposit(beneficiary, amount, from) {
     this.postconditions = {
       balance: await balance.current(this.simpleSwap.address),
       liquidBalance: await this.simpleSwap.liquidBalance(),
-      balanceFor: await this.simpleSwap.balanceFor(beneficiary),
+      availableBalanceFor: await this.simpleSwap.availableBalanceFor(beneficiary),
       totalHardDeposit: await this.simpleSwap.totalHardDeposit(),
       hardDepositFor: await this.simpleSwap.hardDeposits(beneficiary)
     }
@@ -418,8 +418,8 @@ function shouldIncreaseHardDeposit(beneficiary, amount, from) {
     expect(this.postconditions.liquidBalance).bignumber.to.be.equal(this.preconditions.liquidBalance.sub(amount))
   })
 
-  it('should not affect the balanceFor', function () {
-    expect(this.postconditions.balanceFor).bignumber.to.be.equal(this.preconditions.balanceFor)
+  it('should not affect the availableBalanceFor', function () {
+    expect(this.postconditions.availableBalanceFor).bignumber.to.be.equal(this.preconditions.availableBalanceFor)
   })
 
   it('should not affect the balance', function () {
@@ -587,7 +587,7 @@ module.exports = {
   shouldReturnTotalHardDeposit,
   shouldReturnIssuer,
   shouldReturnLiquidBalance,
-  shouldReturnBalanceFor,
+  shouldReturnAvailableBalanceFor,
   shouldCashChequeBeneficiary,
   shouldNotCashChequeBeneficiary,
   shouldCashCheque,

--- a/test/SimpleSwap.should.js
+++ b/test/SimpleSwap.should.js
@@ -49,12 +49,12 @@ function shouldReturnDEFAULT_HARDDEPOSIT_DECREASE_TIMEOUT(expected) {
   })
 }
 
-function shouldReturnPaidOutCheques(beneficiary, expectedAmount) {
+function shouldReturnPaidOut(beneficiary, expectedAmount) {
   beforeEach(async function() {
-    this.paidOutCheque = await this.simpleSwap.paidOutCheques(beneficiary)
+    this.paidOut = await this.simpleSwap.paidOut(beneficiary)
   })
   it('should return the expected amount', function() {
-    expect(expectedAmount).bignumber.to.be.equal(this.paidOutCheque)
+    expect(expectedAmount).bignumber.to.be.equal(this.paidOut)
   })
 }
 
@@ -116,7 +116,7 @@ function shouldReturnBalanceFor(beneficiary, expectedBalanceFor) {
 function cashChequeInternal(beneficiary, recipient, cumulativePayout, calleePayout, from) {
 
   beforeEach(async function() {
-    let requestPayout = cumulativePayout.sub(this.preconditions.paidOutCheque)
+    let requestPayout = cumulativePayout.sub(this.preconditions.paidOut)
     //if the requested payout is less than the liquidBalance available for beneficiary
     if(requestPayout.lt(this.preconditions.balanceFor)) {
       // full amount requested can be paid out
@@ -143,8 +143,8 @@ function cashChequeInternal(beneficiary, recipient, cumulativePayout, calleePayo
     expect(this.postconditions.hardDepositFor.amount).bignumber.to.be.equal(this.preconditions.hardDepositFor.amount.sub(expectedDecreaseHardDeposit))    
   })
   
-  it('should update paidOutCheque', async function() {
-    expect(this.postconditions.paidOutCheque).bignumber.to.be.equal(this.preconditions.paidOutCheque.add(this.totalPayout))
+  it('should update paidOut', async function() {
+    expect(this.postconditions.paidOut).bignumber.to.be.equal(this.preconditions.paidOut.add(this.totalPayout))
   })
 
   it('should transfer the correct amount to the recipient', async function() {
@@ -188,7 +188,7 @@ function cashChequeInternal(beneficiary, recipient, cumulativePayout, calleePayo
     })
   })
   it('should only emit a chequeBounced event when insufficient funds', function() {
-    if(this.totalPayout.lt(cumulativePayout.sub(this.preconditions.paidOutCheque))) {
+    if(this.totalPayout.lt(cumulativePayout.sub(this.preconditions.paidOut))) {
       expectEvent.inLogs(this.logs, "ChequeBounced", {})
     } else {
       const events = this.logs.filter(e => e.event === 'ChequeBounced');
@@ -209,7 +209,7 @@ function shouldCashChequeBeneficiary(recipient, cumulativePayout, signee, from) 
       balanceFor: await this.simpleSwap.balanceFor(from),
       chequebookBalance: await balance.current(this.simpleSwap.address),
       beneficiaryBalance: await balance.current(recipient),
-      paidOutCheque: await this.simpleSwap.paidOutCheques(from)
+      paidOut: await this.simpleSwap.paidOut(from)
     }
 
     const issuerSig = await signCheque(this.simpleSwap, from, cumulativePayout, signee)
@@ -228,7 +228,7 @@ function shouldCashChequeBeneficiary(recipient, cumulativePayout, signee, from) 
       balanceFor: await this.simpleSwap.balanceFor(from),
       chequebookBalance: await balance.current(this.simpleSwap.address),
       beneficiaryBalance: await balance.current(recipient),
-      paidOutCheque: await this.simpleSwap.paidOutCheques(from)
+      paidOut: await this.simpleSwap.paidOut(from)
     }
   })
   cashChequeInternal(from, recipient, cumulativePayout, new BN(0), from)
@@ -261,7 +261,7 @@ function shouldCashCheque(beneficiary, recipient, cumulativePayout, calleePayout
       balanceFor: await this.simpleSwap.balanceFor(beneficiary),
       chequebookBalance: await balance.current(this.simpleSwap.address),
       beneficiaryBalance: await balance.current(recipient),
-      paidOutCheque: await this.simpleSwap.paidOutCheques(beneficiary)
+      paidOut: await this.simpleSwap.paidOut(beneficiary)
     }
     const { logs, receipt } = await this.simpleSwap.cashCheque(beneficiary, recipient, cumulativePayout, beneficiarySig, calleePayout, issuerSig, {from: from})
     this.logs = logs
@@ -277,7 +277,7 @@ function shouldCashCheque(beneficiary, recipient, cumulativePayout, calleePayout
       balanceFor: await this.simpleSwap.balanceFor(beneficiary),
       chequebookBalance: await balance.current(this.simpleSwap.address),
       beneficiaryBalance: await balance.current(recipient),
-      paidOutCheque: await this.simpleSwap.paidOutCheques(beneficiary)
+      paidOut: await this.simpleSwap.paidOut(beneficiary)
     }
   })
   cashChequeInternal(beneficiary, recipient, cumulativePayout, calleePayout, from)
@@ -582,7 +582,7 @@ function shouldNotDeposit(amount, from) {
 module.exports = {
   shouldDeploy,
   shouldReturnDEFAULT_HARDDEPOSIT_DECREASE_TIMEOUT,
-  shouldReturnPaidOutCheques,
+  shouldReturnPaidOut,
   shouldReturnHardDeposits,
   shouldReturnTotalHardDeposit,
   shouldReturnIssuer,

--- a/test/swutils.js
+++ b/test/swutils.js
@@ -1,12 +1,3 @@
-const Swap = artifacts.require('./SimpleSwap')
-const {
-  constants
-} = require("openzeppelin-test-helpers");
-
-function getSwap() {  
-  return Swap.new(constants.ZERO_ADDRESS)    
-}
-
 async function sign(hash, signer) {
   let signature = await web3.eth.sign(hash, signer)
 
@@ -21,17 +12,17 @@ async function signCheque(swap, beneficiary, cumulativePayout, signee) {
     swap.address,
     beneficiary,
     cumulativePayout
-  );
+  )
+
   return await sign(hash, signee)
 }
 
-async function signCashOut(swap, sender, requestPayout, beneficiaryAgent, expiry, calleePayout, signee) {
+async function signCashOut(swap, sender, cumulativePayout, beneficiaryAgent, calleePayout, signee) {
   const hash = await swap.cashOutHash(
     swap.address,
     sender,
-    requestPayout,
+    cumulativePayout,
     beneficiaryAgent,
-    expiry,
     calleePayout
   )
 

--- a/test/swutils.js
+++ b/test/swutils.js
@@ -16,23 +16,13 @@ async function sign(hash, signer) {
   return rs + v.toString(16)
 }
 
-async function signCheque(swap, cheque) {
+async function signCheque(swap, beneficiary, cumulativePayout, signee) {
   const hash = await swap.chequeHash(
     swap.address,
-    cheque.beneficiary,
-    cheque.serial,
-    cheque.amount,
-    cheque.timeout
+    beneficiary,
+    cumulativePayout
   );
-
-  if(cheque.signee.length == 2) {
-    cheque.signature = []
-    cheque.signature.issuer = await sign(hash, cheque.signee[0])
-    cheque.signature.beneficiary = await sign(hash, cheque.signee[1])
-  } else {
-    cheque.signature = await sign(hash, cheque.signee)
-  }
-  return cheque
+  return await sign(hash, signee)
 }
 
 async function signCashOut(swap, sender, requestPayout, beneficiaryAgent, expiry, calleePayout, signee) {


### PR DESCRIPTION
Waivers were removed which:
- made `serial` redundant
- made `amount` (cumulative amount of last submitted cheque) redundant
- made `cashTimeout` redundant.
- made the function `submitcheque` largely redundant
- made `expiry` (in cashCheque) redundant

If anybody but the issuer attempts to cash a cheque, the issuer must have given his approval by his signature (feature from `submitCheque` now to `cashCheque`).

Everything else remained unchanged. 