### PR TITLE
Ci lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ jobs:
       script:
         - docker build -t sw3-travis .
         - docker run -it --rm sw3-travis npm test
+        - docker run -it --rm sw3-travis npm run ethlint
+        - docker run -it --rm sw3-travis npm run solhint


### PR DESCRIPTION
This PR runs the linters after the tests. It does so in the same job(?) as the test to avoid building the image twice and to avoid interacting with a registry. 