### PR TITLE
use packed encoding everywhere / encode cheques js-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,35 @@ The balance not covered by hard deposits can be withdrawn by the issuer at any t
 
 ### Data Formats
 
+#### Signatures
+
+For signing purposes the fields are encoded in **packed encoding** in the order specified below. `SimpleSwap` uses the same signing scheme as `eth_sign` (with the `Ethereum Signed Message` prefix).
+
 #### Cheques
 
-| Field        | Type | Description   |
-| ------------ | ------------- | ------------- |
-| swap        | uint256 | the swap contract this cheque is for |
-| beneficiary  | address | beneficiary of the cheque |
-| cumulativePayout | uint256 | cumulative amount |
+| Field            | Type         | Description   |
+| ---------------- | ------------ | ------------- |
+| swap             | address      | the swap contract this is for |
+| beneficiary      | address      | beneficiary of the cheque |
+| cumulativePayout | uint256      | cumulative amount |
 
-For signing purposes the fields are encoded in **packed encoding** in the order specified above. `SimpleSwap` uses the same signing scheme as `eth_sign` (with the `Ethereum Signed Message` prefix).
+#### CashOut
+
+| Field            | Type         | Description   |
+| ---------------- | ------------ | ------------- |
+| swap             | address      | the swap contract this is for |
+| sender           | address      | the address allowed to submit this cheque |
+| requestPayout    | uint256      | the maximum amount that should be paid out |
+| recipient        | address      | the target of the payment |
+| calleePayout     | uint256      | amount of the payout that should go the caller |
+
+#### CustomHardDepositDecreaseTimeout
+
+| Field            | Type         | Description   |
+| ---------------- | ------------ | ------------- |
+| swap             | address      | the swap contract this is for |
+| beneficiary      | address      | beneficiary of the hard deposit |
+| decreaseTimeout  | uint256      | new timeout |
 
 ## Swap
 

--- a/contracts/SimpleSwap.sol
+++ b/contracts/SimpleSwap.sol
@@ -266,17 +266,18 @@ contract SimpleSwap {
   }
 
   function chequeHash(address swap, address beneficiary, uint cumulativePayout)
-  public pure returns (bytes32) {
+  internal pure returns (bytes32) {
     return keccak256(abi.encodePacked(swap, beneficiary, cumulativePayout));
   }
 
   function cashOutHash(address swap, address sender, uint requestPayout, address recipient, uint calleePayout)
-  public pure returns (bytes32) {
+  internal pure returns (bytes32) {
     return keccak256(abi.encodePacked(swap, sender, requestPayout, recipient, calleePayout));
   }
 
-  function customDecreaseTimeoutHash(address swap, address beneficiary, uint decreaseTimeout) public pure returns (bytes32) {
-    return keccak256(abi.encode(swap, beneficiary, decreaseTimeout));
+  function customDecreaseTimeoutHash(address swap, address beneficiary, uint decreaseTimeout) 
+  internal pure returns (bytes32) {
+    return keccak256(abi.encodePacked(swap, beneficiary, decreaseTimeout));
   }
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2060,6 +2060,39 @@
       "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
       "dev": true
     },
+    "ethereumjs-abi": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.7.tgz",
+      "integrity": "sha512-EMLOA8ICO5yAaXDhjVEfYjsJIXYutY8ufTE93eEKwsVtp2usQreKwsDTJ9zvam3omYqNuffr8IONIqb2uUslGQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.8",
+        "ethereumjs-util": "^6.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+          "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "0.1.6",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        }
+      }
+    },
     "ethereumjs-testrpc-sc": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "bn-chai": "^1.0.1",
     "chai": "^4.2.0",
+    "ethereumjs-abi": "^0.6.7",
     "ethlint": "^1.2.4",
     "openzeppelin-test-helpers": "^0.4.0",
     "solhint": "^2.1.2",

--- a/test/swutils.js
+++ b/test/swutils.js
@@ -1,3 +1,5 @@
+const abi = require('ethereumjs-abi')
+
 async function sign(hash, signer) {
   let signature = await web3.eth.sign(hash, signer)
 
@@ -8,33 +10,29 @@ async function sign(hash, signer) {
 }
 
 async function signCheque(swap, beneficiary, cumulativePayout, signee) {
-  const hash = await swap.chequeHash(
-    swap.address,
-    beneficiary,
-    cumulativePayout
+  const encodedCheque = abi.solidityPack(
+    ['address', 'address', 'uint256'],
+    [swap.address, beneficiary, cumulativePayout]
   )
-
+  const hash = web3.utils.keccak256(encodedCheque)
   return await sign(hash, signee)
 }
 
 async function signCashOut(swap, sender, cumulativePayout, beneficiaryAgent, calleePayout, signee) {
-  const hash = await swap.cashOutHash(
-    swap.address,
-    sender,
-    cumulativePayout,
-    beneficiaryAgent,
-    calleePayout
+  const encodedCashOut = abi.solidityPack(
+    ['address', 'address', 'uint256', 'address', 'uint256'],
+    [swap.address, sender, cumulativePayout, beneficiaryAgent, calleePayout]
   )
-
+  const hash = web3.utils.keccak256(encodedCashOut)
   return await sign(hash, signee)
 }
 
 async function signCustomDecreaseTimeout(swap, beneficiary, decreaseTimeout, signee) {
-  const hash = await swap.customDecreaseTimeoutHash(
-    swap.address,
-    beneficiary,
-    decreaseTimeout
+  const encodedCustomDecreaseTimeout = abi.solidityPack(
+    ['address', 'address', 'uint256'],
+    [swap.address, beneficiary, decreaseTimeout]
   )
+  const hash = web3.utils.keccak256(encodedCustomDecreaseTimeout)
 
   return await sign(hash, signee)
 }


### PR DESCRIPTION
This PR
* changes the encoding of all signed data structure to **packed encoding** (previously it was inconsistent between different messages)
* adds documentation on the data formats
* computes all encoding js side
* makes the hash helpers `internal`