### PR TITLE
enable autogeneration of bindings on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,44 @@
 language: generic
-
 services:
-  - docker
-
+- docker
 branches:
   only:
-    - master
-
+  - master
+  - "/v(\\d+\\.)(\\d+\\.)(\\d)/"
 jobs:
   include:
-    - stage: test
-      script:
-        - docker build -t sw3-travis .
-        - docker run -it --rm sw3-travis npm test
-        - docker run -it --rm sw3-travis npm run ethlint
-        - docker run -it --rm sw3-travis npm run solhint
+  - stage: test
+    script:
+    - docker build -t sw3-travis .
+    - docker run -it --rm sw3-travis npm test
+    - docker run -it --rm sw3-travis npm run ethlint
+    - docker run -it --rm sw3-travis npm run solhint
+  - stage: abigen
+    if: tag IS present
+    script:
+    - docker build -t sw3-travis .
+    - mkdir -p bindings
+    # turn vA.B.C to vA-B-C to avoid . in directory name
+    - export DIRECTORY=$(echo contracts-${TRAVIS_TAG} | tr '.' '-')
+    - docker run -v $(pwd)/bindings:/sw3/bindings sw3-travis npm run abigen
+    # bindings is owned by root at this point
+    - sudo chown -R $(id -u) bindings
+    - git clone "https://${GH_TOKEN}@${GH_REPO}"
+    - mv bindings ${REPO}/${DIRECTORY}
+    - cd ${REPO}
+    - git remote
+    - git config user.email ${EMAIL}
+    - git config user.name ${USER}
+    - git add .
+    - git commit -m "add bindings for ${TRAVIS_TAG}"
+    - git tag ${TRAVIS_TAG}
+    - git push origin master --tags
+env:
+  global:
+  - USER="ralph-pichler"
+  - EMAIL="pichler.ralph@gmail.com"
+  - REPO_USER="ethersphere"
+  - REPO="go-sw3"
+  - GH_REPO="github.com/${REPO_USER}/${REPO}.git"
+  # GH_TOKEN
+  - secure: b8W9Me6I32mzRD7H+ac/J+irthmHjUMaEoz3mCFm/LfLw/2VwgtKZ5Xh06eGekaPeQTJqLcOjYfp/fckWw0LESkKj+Tf6CKrGdx2cImkx7AQtgQGT/ExFWqHnTV7lOUVV+uJo2OxTzhIbM9J1s4f++KWLY+v+XlxzdxEvr68w0ZToqCsac79jUGuYnlZED5AP9TCgUFjPjIp0rnKA4k9y6sMVLPf2MDtvQVz3Cdns2O66fAYz9uWlI89zjM4SNyBnktV0LtkHH/JvPYaeaS7KvfXsPnP6H0BVCQ/UbmUej3JQmTjQ5vgLevIm/MnyaqmQ1ox08VI5q78NUNHfktTsVmemYwsU8R6sbFnE6jR4X+HXoG/97i+U4VCAwOnb7Yuno6p9jabwsRZjVauVdej2gyPJ7z+fCSb6p9aSuUYgMhDEXJt79EtWCtxzvozUelNq75bHzmCtbsHb6ujEtSNd2fiZOdgwJFiXCX8ygeXylSiOrm4Ie4tSRyxKYWDMheuFjHfr7VojFx4OqIdIgGRMA9/WaeZeMAdinOLrMSaLDPOGhVw3JI8y7ndq9Chu7NRPy5kvozgl4ska46uxnTb/fBU8t54SGojbECPpiroOLPHnLNqA67zhTvsSLMEhOVuFcnBh6Z0B4ojzzq32dTsn7TNOqCpPwiFe6+NPBDPqic=

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM node:10.16.0-stretch as builder
 ARG GETH_VERSION="1.9.1-b7b2f60f"
 ARG SOLIDITY_VERSION="0.5.10"
 
-RUN wget "https://github.com/ethereum/solidity/releases/download/v$SOLIDITY_VERSION/solc-static-linux" \
+RUN wget -q "https://github.com/ethereum/solidity/releases/download/v$SOLIDITY_VERSION/solc-static-linux" \
   && chmod +x solc-static-linux \
   && mv solc-static-linux /usr/local/bin/solc \
-  && wget "https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-$GETH_VERSION.tar.gz" \
+  && wget -q "https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-$GETH_VERSION.tar.gz" \
   && tar xvzf "geth-alltools-linux-amd64-$GETH_VERSION.tar.gz" \
   && mv "geth-alltools-linux-amd64-$GETH_VERSION/abigen" /usr/local/bin/abigen \
   && rm -rf "geth-alltools-linux-amd64-$GETH_VERSION" \

--- a/abigen/code.go.js
+++ b/abigen/code.go.js
@@ -8,8 +8,7 @@ function makeCodeFile(contract, path=`contracts/${contract}.sol`) {
   const Contract = output.contracts[`${path}:${contract}`]
   const binRuntime = Contract['bin-runtime']
 
-  return `
-  // Copyright 2019 The Swarm Authors
+  return `  // Copyright 2019 The Swarm Authors
   // This file is part of the Swarm library.
   //
   // The Swarm library is free software: you can redistribute it and/or modify

--- a/abigen/gen.sh
+++ b/abigen/gen.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env sh
 set -e
 
+# contract name
+CONTRACT=$1
 # go package name
-PACKAGE=contract
+PACKAGE=$(echo $CONTRACT | tr '[:upper:]' '[:lower:]')
 # temporary file for compiler output
 COMPILED_JSON=compiled.json
-# contract name
-CONTRACT=SimpleSwap
 # output directory
-OUTPUT=bindings/$CONTRACT
+OUTPUT=bindings/$PACKAGE
 
 # check if all tools are available
 for tool in node solc abigen
@@ -25,11 +25,11 @@ solc \
   openzeppelin-solidity=$(pwd)/node_modules/openzeppelin-solidity\
   --allow-paths node_modules/openzeppelin-solidity/contracts\
   --combined-json=bin,abi,userdoc,devdoc,metadata,bin-runtime\
-  contracts/SimpleSwap.sol > "$COMPILED_JSON"
+  contracts/$CONTRACT.sol > "$COMPILED_JSON"
 
 # generate the bindings
 mkdir -p "$OUTPUT"
-abigen -pkg $PACKAGE -out "$OUTPUT/simpleswap.go" --combined-json "$COMPILED_JSON"
+abigen -pkg $PACKAGE -out "$OUTPUT/$PACKAGE.go" --combined-json "$COMPILED_JSON"
 # this creates a separate file for the runtime binary which is not included by abigen
 node abigen/code.go.js $PACKAGE "$COMPILED_JSON" $CONTRACT > "$OUTPUT/code.go"
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "test": "truffle test",
-    "abigen": "./abigen/gen.sh",
+    "abigen": "./abigen/gen.sh SimpleSwap",
     "solhint": "solhint contracts/SimpleSwap.sol",
     "ethlint": "solium -d contracts",
     "coverage": "solidity-coverage"


### PR DESCRIPTION
This PR enables the autogeneration of the go bindings on every tag of the form `/v(\\d+\\.)(\\d+\\.)(\\d)/` (e.g. `v1.2.3`) if all the tests and linting checks passed. The generated bindings are pushed to https://github.com/ethersphere/go-sw3 (currently empty) as a new commit. A tag is also created.

For now this uses my (@ralph-pichler) github token for push access to the repo.

Furthermore this PR
* disables output from `wget` in Dockerfile as the progress bar spammed the log
* removes the empty line at the beginning of the autogenerated code.go file
* uses lowercase contract name as (go) package name
* removes the hardcoded references to `SimpleSwap` in `abigen/gen.sh`

See https://github.com/ethersphere/swarm/issues/1618#issuecomment-521636015 for the general idea behind this.