### PR TITLE
add totalPaidOut to SimpleSwap

### DIFF
--- a/contracts/ERC20SimpleSwap.sol
+++ b/contracts/ERC20SimpleSwap.sol
@@ -42,6 +42,8 @@ contract ERC20SimpleSwap {
   ERC20 public token;
   /* associates every beneficiary with how much has been paid out to them */
   mapping (address => uint) public paidOut;
+  /* total amount paid out */
+  uint public totalPaidOut;
   /* associates every beneficiary with their HardDeposit */
   mapping (address => HardDeposit) public hardDeposits;
   /* sum of all hard deposits */
@@ -116,6 +118,7 @@ contract ERC20SimpleSwap {
     }
     /* increase the stored paidOut amount to avoid double payout */
     paidOut[beneficiary] = paidOut[beneficiary].add(totalPayout);
+    totalPaidOut = totalPaidOut.add(totalPayout);
     /* do the actual payments */
 
     require(token.transfer(recipient, totalPayout.sub(callerPayout)), "SimpleSwap: SimpleSwap: transfer failed");

--- a/contracts/ERC20SimpleSwap.sol
+++ b/contracts/ERC20SimpleSwap.sol
@@ -73,7 +73,7 @@ contract ERC20SimpleSwap {
   }
 
   /// @return the part of the balance available for a specific beneficiary
-  function availableBalanceFor(address beneficiary) public view returns(uint) {
+  function liquidBalanceFor(address beneficiary) public view returns(uint) {
     return liquidBalance().add(hardDeposits[beneficiary].amount);
   }
   /**
@@ -106,7 +106,7 @@ contract ERC20SimpleSwap {
     /* the requestPayout is the amount requested for payment processing */
     uint requestPayout = cumulativePayout.sub(paidOut[beneficiary]);
     /* calculates acutal payout */
-    uint totalPayout = Math.min(requestPayout, availableBalanceFor(beneficiary));
+    uint totalPayout = Math.min(requestPayout, liquidBalanceFor(beneficiary));
     /* calculates hard-deposit usage */
     uint hardDepositUsage = Math.min(totalPayout, hardDeposits[beneficiary].amount);
     require(totalPayout >= callerPayout, "SimpleSwap: cannot pay caller");

--- a/test/ERC20SimpleSwap.behavior.js
+++ b/test/ERC20SimpleSwap.behavior.js
@@ -10,7 +10,7 @@ const {
   shouldReturnTotalHardDeposit,
   shouldReturnIssuer,
   shouldReturnLiquidBalance,
-  shouldReturnAvailableBalanceFor,
+  shouldReturnLiquidBalanceFor,
   shouldCashChequeBeneficiary,
   shouldNotCashChequeBeneficiary,
   shouldCashCheque,
@@ -36,7 +36,7 @@ enabledTests = {
   totalHardDeposit: true,
   issuer: true,
   liquidBalance: true,
-  availableBalanceFor: true,
+  liquidBalanceFor: true,
   cashChequeBeneficiary: true,
   cashCheque: true,
   prepareDecreaseHardDeposit: true,
@@ -221,16 +221,16 @@ function shouldBehaveLikeERC20SimpleSwap([issuer, alice, bob, carol], DEFAULT_HA
       }
     })
 
-    describe(describeFunction + 'shouldReturnAvailableBalanceFor', function () {
-      if (enabledTests.availableBalanceFor) {
+    describe(describeFunction + 'shouldReturnLiquidBalanceFor', function () {
+      if (enabledTests.liquidBalanceFor) {
         const beneficiary = bob
         const depositAmount = new BN(50)
         context('when there is some balance', function () {
           describe(describePreCondition + 'shoulDeposit', function () {
             shouldDeposit(depositAmount, issuer)
             context('when there are no hard deposits', function () {
-              describe(describeTest + 'shouldReturnAvailableBalanceFor', function () {
-                shouldReturnAvailableBalanceFor(beneficiary, depositAmount)
+              describe(describeTest + 'shouldReturnLiquidBalanceFor', function () {
+                shouldReturnLiquidBalanceFor(beneficiary, depositAmount)
               })
             })
             context('when there are no hard deposits', function () {
@@ -238,16 +238,16 @@ function shouldBehaveLikeERC20SimpleSwap([issuer, alice, bob, carol], DEFAULT_HA
               describe('when these hard deposits are assigned to the beneficiary', function () {
                 describe(describePreCondition + 'shouldIncreaseHardDeposit', function () {
                   shouldIncreaseHardDeposit(beneficiary, hardDeposit, issuer)
-                  describe(describeTest + 'shouldReturnAvailableBalanceFor', function () {
-                    shouldReturnAvailableBalanceFor(beneficiary, depositAmount)
+                  describe(describeTest + 'shouldReturnLiquidBalanceFor', function () {
+                    shouldReturnLiquidBalanceFor(beneficiary, depositAmount)
                   })
                 })
               })
               describe('when these hard deposits are assigned to somebody else', function () {
                 describe(describePreCondition + 'shouldIncreaseHardDeposit', function () {
                   shouldIncreaseHardDeposit(alice, hardDeposit, issuer)
-                  describe(describeTest + 'shouldReturnAvailableBalanceFor', function () {
-                    shouldReturnAvailableBalanceFor(beneficiary, depositAmount.sub(hardDeposit))
+                  describe(describeTest + 'shouldReturnLiquidBalanceFor', function () {
+                    shouldReturnLiquidBalanceFor(beneficiary, depositAmount.sub(hardDeposit))
                   })
                 })
               })
@@ -255,7 +255,7 @@ function shouldBehaveLikeERC20SimpleSwap([issuer, alice, bob, carol], DEFAULT_HA
           })
         })
         describe('when there is no balance', function () {
-          shouldReturnAvailableBalanceFor(beneficiary, new BN(0))
+          shouldReturnLiquidBalanceFor(beneficiary, new BN(0))
         })
       }
     })

--- a/test/ERC20SimpleSwap.should.js
+++ b/test/ERC20SimpleSwap.should.js
@@ -105,9 +105,9 @@ function shouldReturnLiquidBalance(expectedLiquidBalance) {
   })
 }
 
-function shouldReturnAvailableBalanceFor(beneficiary, expectedAvailableBalanceFor) {
+function shouldReturnLiquidBalanceFor(beneficiary, expectedLiquidBalanceFor) {
   it('should return the expected liquidBalance', async function() {
-    expect(await this.ERC20SimpleSwap.availableBalanceFor(beneficiary)).bignumber.to.equal(expectedAvailableBalanceFor)
+    expect(await this.ERC20SimpleSwap.liquidBalanceFor(beneficiary)).bignumber.to.equal(expectedLiquidBalanceFor)
   })
 }
 
@@ -117,12 +117,12 @@ function cashChequeInternal(beneficiary, recipient, cumulativePayout, callerPayo
   beforeEach(async function() {
     let requestPayout = cumulativePayout.sub(this.preconditions.paidOut)
     //if the requested payout is less than the liquidBalance available for beneficiary
-    if(requestPayout.lt(this.preconditions.availableBalanceFor)) {
+    if(requestPayout.lt(this.preconditions.liquidBalanceFor)) {
       // full amount requested can be paid out
       this.totalPayout = requestPayout
     } else {
       // partial amount requested can be paid out (the liquid balance available to the node)
-      this.totalPayout = this.preconditions.availableBalanceFor
+      this.totalPayout = this.preconditions.liquidBalanceFor
     }
     this.totalPaidOut = this.preconditions.totalPaidOut + this.totalPayout
   })
@@ -192,7 +192,7 @@ function shouldCashChequeBeneficiary(recipient, cumulativePayout, signee, from) 
       totalHardDeposit: await this.ERC20SimpleSwap.totalHardDeposit(),
       hardDepositFor: await this.ERC20SimpleSwap.hardDeposits(from),
       liquidBalance: await this.ERC20SimpleSwap.liquidBalance(),
-      availableBalanceFor: await this.ERC20SimpleSwap.availableBalanceFor(from),
+      liquidBalanceFor: await this.ERC20SimpleSwap.liquidBalanceFor(from),
       chequebookBalance: await this.ERC20SimpleSwap.balance(),
       paidOut: await this.ERC20SimpleSwap.paidOut(from),
       totalPaidOut: await this.ERC20SimpleSwap.totalPaidOut()
@@ -210,7 +210,7 @@ function shouldCashChequeBeneficiary(recipient, cumulativePayout, signee, from) 
       totalHardDeposit: await this.ERC20SimpleSwap.totalHardDeposit(),
       hardDepositFor: await this.ERC20SimpleSwap.hardDeposits(from),
       liquidBalance: await this.ERC20SimpleSwap.liquidBalance(),
-      availableBalanceFor: await this.ERC20SimpleSwap.availableBalanceFor(from),
+      liquidBalanceFor: await this.ERC20SimpleSwap.liquidBalanceFor(from),
       chequebookBalance: await this.ERC20SimpleSwap.balance(),
       paidOut: await this.ERC20SimpleSwap.paidOut(from),
       totalPaidOut: await this.ERC20SimpleSwap.totalPaidOut()
@@ -242,7 +242,7 @@ function shouldCashCheque(beneficiary, recipient, cumulativePayout, callerPayout
       totalHardDeposit: await this.ERC20SimpleSwap.totalHardDeposit(),
       hardDepositFor: await this.ERC20SimpleSwap.hardDeposits(beneficiary),
       liquidBalance: await this.ERC20SimpleSwap.liquidBalance(),
-      availableBalanceFor: await this.ERC20SimpleSwap.availableBalanceFor(beneficiary),
+      liquidBalanceFor: await this.ERC20SimpleSwap.liquidBalanceFor(beneficiary),
       chequebookBalance: await this.ERC20SimpleSwap.balance(),
       paidOut: await this.ERC20SimpleSwap.paidOut(beneficiary),
       totalPaidOut: await this.ERC20SimpleSwap.totalPaidOut()
@@ -257,7 +257,7 @@ function shouldCashCheque(beneficiary, recipient, cumulativePayout, callerPayout
       totalHardDeposit: await this.ERC20SimpleSwap.totalHardDeposit(),
       hardDepositFor: await this.ERC20SimpleSwap.hardDeposits(beneficiary),
       liquidBalance: await this.ERC20SimpleSwap.liquidBalance(),
-      availableBalanceFor: await this.ERC20SimpleSwap.availableBalanceFor(beneficiary),
+      liquidBalanceFor: await this.ERC20SimpleSwap.liquidBalanceFor(beneficiary),
       chequebookBalance: await this.ERC20SimpleSwap.balance(),
       paidOut: await this.ERC20SimpleSwap.paidOut(beneficiary),
       totalPaidOut: await this.ERC20SimpleSwap.totalPaidOut()
@@ -382,7 +382,7 @@ function shouldIncreaseHardDeposit(beneficiary, amount, from) {
     this.preconditions = {
       balance: await this.ERC20SimpleSwap.balance(),
       liquidBalance: await this.ERC20SimpleSwap.liquidBalance(),
-      availableBalanceFor: await this.ERC20SimpleSwap.availableBalanceFor(beneficiary),
+      liquidBalanceFor: await this.ERC20SimpleSwap.liquidBalanceFor(beneficiary),
       totalHardDeposit: await this.ERC20SimpleSwap.totalHardDeposit(),
       hardDepositFor: await this.ERC20SimpleSwap.hardDeposits(beneficiary),
     }
@@ -391,7 +391,7 @@ function shouldIncreaseHardDeposit(beneficiary, amount, from) {
     this.postconditions = {
       balance: await this.ERC20SimpleSwap.balance(),
       liquidBalance: await this.ERC20SimpleSwap.liquidBalance(),
-      availableBalanceFor: await this.ERC20SimpleSwap.availableBalanceFor(beneficiary),
+      liquidBalanceFor: await this.ERC20SimpleSwap.liquidBalanceFor(beneficiary),
       totalHardDeposit: await this.ERC20SimpleSwap.totalHardDeposit(),
       hardDepositFor: await this.ERC20SimpleSwap.hardDeposits(beneficiary)
     }
@@ -401,8 +401,8 @@ function shouldIncreaseHardDeposit(beneficiary, amount, from) {
     expect(this.postconditions.liquidBalance).bignumber.to.be.equal(this.preconditions.liquidBalance.sub(amount))
   })
 
-  it('should not affect the availableBalanceFor', function () {
-    expect(this.postconditions.availableBalanceFor).bignumber.to.be.equal(this.preconditions.availableBalanceFor)
+  it('should not affect the liquidBalanceFor', function () {
+    expect(this.postconditions.liquidBalanceFor).bignumber.to.be.equal(this.preconditions.liquidBalanceFor)
   })
 
   it('should not affect the balance', function () {
@@ -548,7 +548,7 @@ module.exports = {
   shouldReturnTotalHardDeposit,
   shouldReturnIssuer,
   shouldReturnLiquidBalance,
-  shouldReturnAvailableBalanceFor,
+  shouldReturnLiquidBalanceFor,
   shouldCashChequeBeneficiary,
   shouldNotCashChequeBeneficiary,
   shouldCashCheque,

--- a/test/ERC20SimpleSwap.should.js
+++ b/test/ERC20SimpleSwap.should.js
@@ -48,6 +48,15 @@ function shouldReturnPaidOut(beneficiary, expectedAmount) {
   })
 }
 
+function shouldReturnTotalPaidOut(expectedAmount) {
+  beforeEach(async function() {
+    this.totalPaidOut = await this.ERC20SimpleSwap.totalPaidOut()
+  })
+  it('should return the expected amount', function() {
+    expect(expectedAmount).bignumber.to.be.equal(this.totalPaidOut)
+  })
+}
+
 function shouldReturnHardDeposits(beneficiary, expectedAmount, expectedDecreaseAmount,  expectedDecreaseTimeout, expectedCanBeDecreasedAt) {
   beforeEach(async function() {
     // If we expect this not to be the default value, we have to set the value here, as it depends on the most current time
@@ -115,6 +124,7 @@ function cashChequeInternal(beneficiary, recipient, cumulativePayout, callerPayo
       // partial amount requested can be paid out (the liquid balance available to the node)
       this.totalPayout = this.preconditions.availableBalanceFor
     }
+    this.totalPaidOut = this.preconditions.totalPaidOut + this.totalPayout
   })
   
   it('should update the totalHardDeposit and hardDepositFor ', function() {
@@ -135,6 +145,10 @@ function cashChequeInternal(beneficiary, recipient, cumulativePayout, callerPayo
   
   it('should update paidOut', async function() {
     expect(this.postconditions.paidOut).bignumber.to.be.equal(this.preconditions.paidOut.add(this.totalPayout))
+  })
+
+  it('should update totalPaidOut', async function() {
+    expect(this.postconditions.totalPaidOut).bignumber.to.be.equal(this.preconditions.paidOut.add(this.totalPayout))
   })
 
   it('should transfer the correct amount to the recipient', async function() {
@@ -180,7 +194,8 @@ function shouldCashChequeBeneficiary(recipient, cumulativePayout, signee, from) 
       liquidBalance: await this.ERC20SimpleSwap.liquidBalance(),
       availableBalanceFor: await this.ERC20SimpleSwap.availableBalanceFor(from),
       chequebookBalance: await this.ERC20SimpleSwap.balance(),
-      paidOut: await this.ERC20SimpleSwap.paidOut(from)
+      paidOut: await this.ERC20SimpleSwap.paidOut(from),
+      totalPaidOut: await this.ERC20SimpleSwap.totalPaidOut()
     }
 
     const issuerSig = await signCheque(this.ERC20SimpleSwap, from, cumulativePayout, signee)
@@ -197,7 +212,8 @@ function shouldCashChequeBeneficiary(recipient, cumulativePayout, signee, from) 
       liquidBalance: await this.ERC20SimpleSwap.liquidBalance(),
       availableBalanceFor: await this.ERC20SimpleSwap.availableBalanceFor(from),
       chequebookBalance: await this.ERC20SimpleSwap.balance(),
-      paidOut: await this.ERC20SimpleSwap.paidOut(from)
+      paidOut: await this.ERC20SimpleSwap.paidOut(from),
+      totalPaidOut: await this.ERC20SimpleSwap.totalPaidOut()
     }
   })
   cashChequeInternal(from, recipient, cumulativePayout, new BN(0), from)
@@ -228,7 +244,8 @@ function shouldCashCheque(beneficiary, recipient, cumulativePayout, callerPayout
       liquidBalance: await this.ERC20SimpleSwap.liquidBalance(),
       availableBalanceFor: await this.ERC20SimpleSwap.availableBalanceFor(beneficiary),
       chequebookBalance: await this.ERC20SimpleSwap.balance(),
-      paidOut: await this.ERC20SimpleSwap.paidOut(beneficiary)
+      paidOut: await this.ERC20SimpleSwap.paidOut(beneficiary),
+      totalPaidOut: await this.ERC20SimpleSwap.totalPaidOut()
     }
     const { logs, receipt } = await this.ERC20SimpleSwap.cashCheque(beneficiary, recipient, cumulativePayout, beneficiarySig, callerPayout, issuerSig, {from: from})
     this.logs = logs
@@ -242,7 +259,8 @@ function shouldCashCheque(beneficiary, recipient, cumulativePayout, callerPayout
       liquidBalance: await this.ERC20SimpleSwap.liquidBalance(),
       availableBalanceFor: await this.ERC20SimpleSwap.availableBalanceFor(beneficiary),
       chequebookBalance: await this.ERC20SimpleSwap.balance(),
-      paidOut: await this.ERC20SimpleSwap.paidOut(beneficiary)
+      paidOut: await this.ERC20SimpleSwap.paidOut(beneficiary),
+      totalPaidOut: await this.ERC20SimpleSwap.totalPaidOut()
     }
   })
   cashChequeInternal(beneficiary, recipient, cumulativePayout, callerPayout, from)


### PR DESCRIPTION
This PR adds the `totalPaidOut` variable to track the sum of all historical payouts. Also renames `availableBalanceFor` to `liquidBalanceFor`.

closes #91
closes #92 