### PR TITLE
version bump to 0.2.0

### DIFF
--- a/Dockerfile.abigen
+++ b/Dockerfile.abigen
@@ -1,7 +1,7 @@
 FROM node:10.16.0-stretch as builder
 
-ARG GETH_VERSION="1.9.1-b7b2f60f"
-ARG SOLIDITY_VERSION="0.5.11"
+ARG GETH_VERSION="1.9.7-a718daa6"
+ARG SOLIDITY_VERSION="0.5.13"
 
 RUN wget -q "https://github.com/ethereum/solidity/releases/download/v$SOLIDITY_VERSION/solc-static-linux" \
   && chmod +x solc-static-linux \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sw3",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sw3",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "",
   "main": "truffle.js",
   "directories": {

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -73,7 +73,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.5.11",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.5.13",    // Fetch exact version from solc-bin (default: truffle's version)
       settings: {          // See the solidity docs for advice about optimization and evmVersion
        optimizer: {
          enabled: true,


### PR DESCRIPTION
Version bump for bindings of the new ERC20 implementation. Also updates to latest solidity and abigen.

After merge the `v0.2.0` tag will be created and pushed, triggering the go binding generation.