### PR TITLE
always require a signed cheque

### DIFF
--- a/contracts/ERC20SimpleSwap.sol
+++ b/contracts/ERC20SimpleSwap.sol
@@ -93,18 +93,16 @@ contract ERC20SimpleSwap {
     uint callerPayout,
     bytes memory issuerSig
   ) internal {
-    /* The issuer must have given explicit approval to the cumulativePayout, either by being the caller or by signature*/
-    if (msg.sender != issuer) {
-      require(
-        issuer == recover(
-          chequeHash(
-            address(this),
-            beneficiary,
-            cumulativePayout
-          ), issuerSig
-        ), "SimpleSwap: invalid issuerSig"
-      );
-    }
+    /* The issuer must have given explicit approval to the cumulativePayout by signature */
+    require(
+      issuer == recover(
+        chequeHash(
+          address(this),
+          beneficiary,
+          cumulativePayout
+        ), issuerSig
+      ), "SimpleSwap: invalid issuerSig"
+    );
     /* the requestPayout is the amount requested for payment processing */
     uint requestPayout = cumulativePayout.sub(paidOut[beneficiary]);
     /* calculates acutal payout */

--- a/test/ERC20SimpleSwap.behavior.js
+++ b/test/ERC20SimpleSwap.behavior.js
@@ -432,7 +432,7 @@ function shouldBehaveLikeERC20SimpleSwap([issuer, alice, bob, carol], defaultHar
           const caller = issuer
           const callerPayout = new BN(0)
           const beneficiarySignee = beneficiary
-          const issuerSignee = beneficiary // on purpose not the correct signee, as it is not needed
+          const issuerSignee = issuer
           describe(describeTest + 'shouldCashCheque', function() {
             shouldCashCheque(beneficiary, recipient, firstCumulativePayout, callerPayout, caller, beneficiarySignee, issuerSignee)
           })


### PR DESCRIPTION
This removes the optimisation where the cheque signature is not verified if the caller is the issuer. While technically there is nothing wrong with that it can lead to some confusing behaviour.