### PR TITLE
use go-ethereum 1.9.20

### DIFF
--- a/Dockerfile.abigen
+++ b/Dockerfile.abigen
@@ -1,6 +1,6 @@
 FROM node:10.16.0-stretch as builder
 
-ARG GETH_VERSION="1.9.7-a718daa6"
+ARG GETH_VERSION="1.9.20-979fc968"
 ARG SOLIDITY_VERSION="0.6.12"
 
 RUN wget -q "https://github.com/ethereum/solidity/releases/download/v$SOLIDITY_VERSION/solc-static-linux" \


### PR DESCRIPTION
use the same version for the go bindings which bee currently uses.