### PR TITLE
eip-712 cheques

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The balance not covered by hard deposits can be withdrawn by the issuer at any t
 
 #### Signatures
 
-For signing purposes the chequebook uses EIP-712 Ethereum typed structured data hashing and signing. The `EIP712Domain` domain name is `ERC20SimpleSwap` in version `1.0`. The `chainId` field is used, the `verifyingContract` and `salt` fields are omitted.
+For signing purposes the chequebook uses EIP-712 Ethereum typed structured data hashing and signing. The `EIP712Domain` domain name is `Chequebook` in version `1.0`. The `chainId` field is used, the `verifyingContract` and `salt` fields are omitted.
 
 #### Cheques
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The balance not covered by hard deposits can be withdrawn by the issuer at any t
 
 #### Signatures
 
-For signing purposes the chequebook uses EIP-712 Ethereum typed structured data hashing and signing. The `EIP712Domain` domain name is `ERC20SimpleSwap` in version `1.0`. The `chainId` field is used, the `verifyingContract` is omitted.
+For signing purposes the chequebook uses EIP-712 Ethereum typed structured data hashing and signing. The `EIP712Domain` domain name is `ERC20SimpleSwap` in version `1.0`. The `chainId` field is used, the `verifyingContract` and `salt` fields are omitted.
 
 #### Cheques
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The balance not covered by hard deposits can be withdrawn by the issuer at any t
 
 #### Signatures
 
-For signing purposes the fields are encoded in **packed encoding** in the order specified below. `SimpleSwap` uses the same signing scheme as `eth_sign` (with the `Ethereum Signed Message` prefix).
+For signing purposes the chequebook uses EIP-712 Ethereum typed structured data hashing and signing. The `EIP712Domain` domain name is `ERC20SimpleSwap` in version `1.0`. The `chainId` field is used, the `verifyingContract` is omitted.
 
 #### Cheques
 

--- a/contracts/ERC20SimpleSwap.sol
+++ b/contracts/ERC20SimpleSwap.sol
@@ -64,7 +64,7 @@ contract ERC20SimpleSwap {
       chainId := chainid()
     }
     return EIP712Domain({
-      name: "ERC20SimpleSwap",
+      name: "Chequebook",
       version: "1.0",
       chainId: chainId
     });

--- a/test/ERC20SimpleSwap.behavior.js
+++ b/test/ERC20SimpleSwap.behavior.js
@@ -370,7 +370,7 @@ function shouldBehaveLikeERC20SimpleSwap([issuer, alice, bob, carol], defaultHar
               context('when the issuer does not provide the issuerSig', function () {
                 const issuerSignee = alice
                 const callerPayout = defaults.firstCumulativePayout.div(new BN(100))
-                const revertMessage = 'SimpleSwap: invalid issuerSig'
+                const revertMessage = 'SimpleSwap: invalid issuer signature'
                 const beneficiaryToSign = {
                   cumulativePayout: firstCumulativePayout,
                   recipient,
@@ -391,7 +391,7 @@ function shouldBehaveLikeERC20SimpleSwap([issuer, alice, bob, carol], defaultHar
               const beneficiarySignee = alice
               const issuerSignee = issuer
               const callerPayout = defaults.firstCumulativePayout.div(new BN(100))
-              const revertMessage = 'SimpleSwap: invalid beneficiarySig'
+              const revertMessage = 'SimpleSwap: invalid beneficiary signature'
               const beneficiaryToSign = {
                 cumulativePayout: firstCumulativePayout,
                 recipient,
@@ -541,7 +541,7 @@ function shouldBehaveLikeERC20SimpleSwap([issuer, alice, bob, carol], defaultHar
               })
             })
             context('when the signee does not sign the correct fields', function () {
-              const revertMessage = "SimpleSwap: invalid issuerSig"
+              const revertMessage = "SimpleSwap: invalid issuer signature"
               const recipient = defaults.recipient
               const toSubmitCumulativePayment = defaults.firstCumulativePayout
               const toSignCumulativePayment = new BN(1)
@@ -550,7 +550,7 @@ function shouldBehaveLikeERC20SimpleSwap([issuer, alice, bob, carol], defaultHar
             })
           })
           context('when the issuer is not a signee', function () {
-            const revertMessage = "SimpleSwap: invalid issuerSig"
+            const revertMessage = "SimpleSwap: invalid issuer signature"
             const signee = alice
             const recipient = defaults.recipient
             const toSubmitCumulativePayment = defaults.firstCumulativePayout
@@ -785,7 +785,7 @@ function shouldBehaveLikeERC20SimpleSwap([issuer, alice, bob, carol], defaultHar
                 describe(describeTest + 'shouldNotSetCustomHardDepositTimeout', function () {
                   const toSubmit = { beneficiary, timeout }
                   const toSign = { beneficiary, timeout: timeout.sub(new BN(1)) }
-                  const revertMessage = "SimpleSwap: invalid beneficiarySig"
+                  const revertMessage = "SimpleSwap: invalid beneficiary signature"
                   shouldNotSetCustomHardDepositTimeout(toSubmit, toSign, signee, sender, value, revertMessage)
                 })
               })
@@ -795,7 +795,7 @@ function shouldBehaveLikeERC20SimpleSwap([issuer, alice, bob, carol], defaultHar
               describe(describeTest + 'shouldNotSetCustomHardDepositTimeout', function () {
                 const toSubmit = { beneficiary, timeout }
                 const toSign = toSubmit
-                const revertMessage = "SimpleSwap: invalid beneficiarySig"
+                const revertMessage = "SimpleSwap: invalid beneficiary signature"
                 shouldNotSetCustomHardDepositTimeout(toSubmit, toSign, signee, sender, value, revertMessage)
               })
             })

--- a/test/swutils.js
+++ b/test/swutils.js
@@ -59,7 +59,7 @@ async function signCheque(swap, beneficiary, cumulativePayout, signee, chainId =
       Cheque: ChequeType
     },
     domain: {
-      name: "ERC20SimpleSwap",
+      name: "Chequebook",
       version: "1.0",
       chainId
     },
@@ -77,7 +77,7 @@ async function signCashOut(swap, sender, cumulativePayout, beneficiaryAgent, cal
       Cashout: CashoutType
     },
     domain: {
-      name: "ERC20SimpleSwap",
+      name: "Chequebook",
       version: "1.0",
       chainId
     },
@@ -101,7 +101,7 @@ async function signCustomDecreaseTimeout(swap, beneficiary, decreaseTimeout, sig
       CustomDecreaseTimeout: CustomDecreaseTimeoutType
     },
     domain: {
-      name: "ERC20SimpleSwap",
+      name: "Chequebook",
       version: "1.0",
       chainId
     },

--- a/test/swutils.js
+++ b/test/swutils.js
@@ -7,13 +7,13 @@ const EIP712Domain = [
 ]
 
 const ChequeType = [
-  { name: 'swap', type: 'address' },
+  { name: 'chequebook', type: 'address' },
   { name: 'beneficiary', type: 'address' },
   { name: 'cumulativePayout', type: 'uint256' }
 ]
 
 const CashoutType = [
-  { name: 'swap', type: 'address' },
+  { name: 'chequebook', type: 'address' },
   { name: 'sender', type: 'address' },
   { name: 'requestPayout', type: 'uint256' },
   { name: 'recipient', type: 'address' },
@@ -21,7 +21,7 @@ const CashoutType = [
 ]
 
 const CustomDecreaseTimeoutType = [
-  { name: 'swap', type: 'address' },
+  { name: 'chequebook', type: 'address' },
   { name: 'beneficiary', type: 'address' },
   { name: 'decreaseTimeout', type: 'uint256' }
 ]
@@ -48,7 +48,7 @@ function signTypedData(eip712data, signee) {
 // the chainId is set to 1 due to bug in ganache where the wrong id is reported via rpc
 async function signCheque(swap, beneficiary, cumulativePayout, signee, chainId = 1) {
   const cheque = {
-    swap: swap.address,
+    chequebook: swap.address,
     beneficiary,
     cumulativePayout: cumulativePayout.toNumber()
   }
@@ -83,7 +83,7 @@ async function signCashOut(swap, sender, cumulativePayout, beneficiaryAgent, cal
     },
     primaryType: 'Cashout',
     message: {
-      swap: swap.address,
+      chequebook: swap.address,
       sender,
       requestPayout: cumulativePayout.toNumber(),
       recipient: beneficiaryAgent,
@@ -107,7 +107,7 @@ async function signCustomDecreaseTimeout(swap, beneficiary, decreaseTimeout, sig
     },
     primaryType: 'CustomDecreaseTimeout',
     message: {
-      swap: swap.address,
+      chequebook: swap.address,
       beneficiary,
       decreaseTimeout: decreaseTimeout.toNumber()
     }

--- a/test/swutils.js
+++ b/test/swutils.js
@@ -45,6 +45,7 @@ function signTypedData(eip712data, signee) {
   )
 }
 
+// the chainId is set to 1 due to bug in ganache where the wrong id is reported via rpc
 async function signCheque(swap, beneficiary, cumulativePayout, signee, chainId = 1) {
   const cheque = {
     swap: swap.address,


### PR DESCRIPTION
Moves everything to EIP-712 signatures (as described in https://eips.ethereum.org/EIPS/eip-712). This is to enable better (or really any at all) verifications on the signer side. Should somebody attempt to sign cheques through MetaMask for some reason this will also be displayed nicely.

closes #28 