### PR TITLE
go library automation

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,0 +1,63 @@
+name: codegen
+
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+
+    # Restore the yarn cache
+    - uses: c-hive/gha-yarn-cache@v1
+
+    - name: Yarn install
+      run: yarn install
+
+    - name: Yarn Compile
+      run: yarn compile
+
+    - uses: actions/checkout@v2
+      with:
+        repository: ethersphere/go-sw3-abi
+        path: go
+        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+        ref: master
+
+    - name: Get tag
+      id: tag
+      uses: dawidd6/action-get-tag@v1
+
+    - name: Commit files
+      run: |
+        mkdir -p go/sw3abi
+        ./codegen/go.sh "go/sw3abi/abi_${{steps.tag.outputs.tag}}.go" "${{steps.tag.outputs.tag}}"
+        cd go
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add .
+        git commit -m "generate code for sw3 contracts ${{steps.tag.outputs.tag}}" -a
+        git tag "${{steps.tag.outputs.tag}}"
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        repository: ethersphere/go-sw3-abi
+        directory: go
+        github_token: ${{ secrets.GH_TOKEN }}
+        branch: master
+        tags: true

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -47,8 +47,8 @@ jobs:
         mkdir -p go/sw3abi
         ./codegen/go.sh "go/sw3abi/abi_${{steps.tag.outputs.tag}}.go" "${{steps.tag.outputs.tag}}"
         cd go
-        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
+        git config --local user.email "bee-worker@ethswarm.org"
+        git config --local user.name "bee-worker"
         git add .
         git commit -m "generate code for sw3 contracts ${{steps.tag.outputs.tag}}" -a
         git tag "${{steps.tag.outputs.tag}}"

--- a/codegen/go.sh
+++ b/codegen/go.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+yarn compile
+
+TARGET="$1"
+VERSION="$(echo $2 | tr . _)"
+
+SIMPLESWAP_ABI="$(cat artifacts/contracts/ERC20SimpleSwap.sol/ERC20SimpleSwap.json | jq .abi)"
+SIMPLESWAP_FACTORY_ABI="$(cat artifacts/contracts/SimpleSwapFactory.sol/SimpleSwapFactory.json | jq .abi)"
+SIMPLESWAP_FACTORY_BYTECODE="$(cat artifacts/contracts/SimpleSwapFactory.sol/SimpleSwapFactory.json | jq .bytecode)"
+ERC20_ABI="$(cat artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json | jq .abi)"
+
+cat <<EOF > "$TARGET"
+// Copyright 2021 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sw3abi
+
+const ERC20SimpleSwapABI$VERSION = \`$SIMPLESWAP_ABI\`
+
+const SimpleSwapFactoryABI$VERSION = \`$SIMPLESWAP_FACTORY_ABI\`
+
+const ERC20ABI$VERSION = \`$ERC20_ABI\`
+
+const SimpleSwapFactoryBin$VERSION = $SIMPLESWAP_FACTORY_BYTECODE
+EOF

--- a/codegen/go.sh
+++ b/codegen/go.sh
@@ -7,6 +7,7 @@ VERSION="$(echo $2 | tr . _)"
 SIMPLESWAP_ABI="$(cat artifacts/contracts/ERC20SimpleSwap.sol/ERC20SimpleSwap.json | jq .abi)"
 SIMPLESWAP_FACTORY_ABI="$(cat artifacts/contracts/SimpleSwapFactory.sol/SimpleSwapFactory.json | jq .abi)"
 SIMPLESWAP_FACTORY_BYTECODE="$(cat artifacts/contracts/SimpleSwapFactory.sol/SimpleSwapFactory.json | jq .bytecode)"
+SIMPLESWAP_FACTORY_DEPLOYED_BYTECODE="$(cat artifacts/contracts/SimpleSwapFactory.sol/SimpleSwapFactory.json | jq .deployedBytecode)"
 ERC20_ABI="$(cat artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json | jq .abi)"
 
 cat <<EOF > "$TARGET"
@@ -23,4 +24,5 @@ const SimpleSwapFactoryABI$VERSION = \`$SIMPLESWAP_FACTORY_ABI\`
 const ERC20ABI$VERSION = \`$ERC20_ABI\`
 
 const SimpleSwapFactoryBin$VERSION = $SIMPLESWAP_FACTORY_BYTECODE
+const SimpleSwapFactoryDeployedBin$VERSION = $SIMPLESWAP_FACTORY_DEPLOYED_BYTECODE
 EOF


### PR DESCRIPTION
this automatically adds abi information to a go library (at ethersphere/go-sw3-abi) on every tag.

for every tags it adds 4 constants (where M_M_R is semver with _ instead of .):
* `ERC20SimpleSwapABIvM_M_R`
* `SimpleSwapFactoryABIvM_M_R`
* `ERC20ABIvM_M_R`
* `SimpleSwapFactoryBinvM_M_R` (not directly used by bee but useful for tooling)
* `SimpleSwapFactoryDeployedBinvM_M_R` (the factory deployed bytecode)

The go library is then tagged with the same tag.