### PR TITLE
enable optimizer

### DIFF
--- a/contracts/ERC20SimpleSwap.sol
+++ b/contracts/ERC20SimpleSwap.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity =0.7.6;
+pragma abicoder v2;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/math/Math.sol";
 import "@openzeppelin/contracts/cryptography/ECDSA.sol";

--- a/contracts/SimpleSwapFactory.sol
+++ b/contracts/SimpleSwapFactory.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity =0.7.6;
+pragma abicoder v2;
 import "./ERC20SimpleSwap.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -15,7 +15,14 @@ const accounts = { mnemonic };
 
 // Config for hardhat.
 module.exports = {
-  solidity: { version: '0.7.6' },  
+  solidity: { version: '0.7.6',
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200
+      },
+    }
+  },  
   networks: {
     hardhat: {
       accounts,

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,5 +1,0 @@
-var Migrations = artifacts.require("./Migrations.sol");
-
-module.exports = function(deployer, network, accounts) {
-  deployer.deploy(Migrations);
-};


### PR DESCRIPTION
was disabled when migrating to hardhat.

* abicoder was set to v2. for unknown reasons the tests fail with optimizer enabled on v1 (reverts with `function was called with incorrect parameters` for the withdraw call).
* also deletes the now unnecessary migrations directly